### PR TITLE
customer 예치금 관리구현

### DIFF
--- a/userApi/src/main/java/com/zerobase/userApi/domain/customer/Customer.java
+++ b/userApi/src/main/java/com/zerobase/userApi/domain/customer/Customer.java
@@ -36,6 +36,9 @@ public class Customer extends BaseEntity{
     private String verificationCode;
     private boolean verify = false;
 
+    @Column(columnDefinition = "int default 0")
+    private Integer balance;
+
     private List<String> roles;
 
     public void changeVerificationInfo(
@@ -45,5 +48,10 @@ public class Customer extends BaseEntity{
         this.verifyExpiredAt = verifyExpiredAt;
         this.verificationCode = verificationCode;
         this.verify = verify;
+    }
+
+    public void setBalance(Integer balance)
+    {
+        this.balance = balance;
     }
 }

--- a/userApi/src/main/java/com/zerobase/userApi/domain/customer/CustomerBalanceHistory.java
+++ b/userApi/src/main/java/com/zerobase/userApi/domain/customer/CustomerBalanceHistory.java
@@ -1,0 +1,30 @@
+package com.zerobase.userApi.domain.customer;
+
+import com.zerobase.userApi.domain.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class CustomerBalanceHistory extends BaseEntity{
+    @Id
+    @Column(name = "id", nullable = false)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "CUSTOMER_ID")
+    private Customer customer;
+    // 결제 후
+    private Integer changeMoney;
+    // 결제 전
+    private Integer currentMoney;
+    private String fromMessage;
+    private String description;
+}

--- a/userApi/src/main/java/com/zerobase/userApi/dto/ChangeBalanceDto.java
+++ b/userApi/src/main/java/com/zerobase/userApi/dto/ChangeBalanceDto.java
@@ -1,0 +1,28 @@
+package com.zerobase.userApi.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class ChangeBalanceDto {
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Getter
+    @Builder
+    public static class Input
+    {
+        Integer money;
+        String message;
+        String from;
+    }
+
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Getter
+    @Builder
+    public static class Output
+    {
+        Integer balance;
+    }
+}

--- a/userApi/src/main/java/com/zerobase/userApi/exception/ErrorCode.java
+++ b/userApi/src/main/java/com/zerobase/userApi/exception/ErrorCode.java
@@ -11,7 +11,8 @@ public enum ErrorCode {
     SEND_EMAIL_ERROR(HttpStatus.BAD_REQUEST, "이메일 전송에 실패하였습니다"),
     VERIFICATION_FAILED(HttpStatus.BAD_REQUEST, "검증에 실패하였습니다."),
     VERIFICATION_REQUIRED(HttpStatus.BAD_REQUEST, "검증되지 않은 유저입니다."),
-    USER_NOT_FOUND(HttpStatus.BAD_REQUEST, "일치하는 유저가 없습니다.");
+    USER_NOT_FOUND(HttpStatus.BAD_REQUEST, "일치하는 유저가 없습니다."),
+    NOT_ENOUGH_BALANCE(HttpStatus.BAD_REQUEST, "잔액이 부족합니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/userApi/src/main/java/com/zerobase/userApi/repository/customer/CustomerBalanceHistoryRepository.java
+++ b/userApi/src/main/java/com/zerobase/userApi/repository/customer/CustomerBalanceHistoryRepository.java
@@ -1,0 +1,18 @@
+package com.zerobase.userApi.repository.customer;
+
+import com.zerobase.userApi.domain.customer.CustomerBalanceHistory;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface CustomerBalanceHistoryRepository extends JpaRepository<CustomerBalanceHistory, Long> {
+    @Query("select h from CustomerBalanceHistory h " +
+            "where h.id = (select max(h2.id) " +
+                            "from CustomerBalanceHistory h2 join h2.customer c " +
+                            "where c.id=:customer_id)")
+    Optional<CustomerBalanceHistory> findByCustomerIdRecent(@Param("customer_id") Long customerId);
+}

--- a/userApi/src/main/java/com/zerobase/userApi/security/JwtTokenProvider.java
+++ b/userApi/src/main/java/com/zerobase/userApi/security/JwtTokenProvider.java
@@ -64,14 +64,14 @@ public class JwtTokenProvider {
         if(roles.contains(Authority.CUSTOMER.getRole())) {
             UserDetails userDetails = customerService.loadUserByUsername(email);
             return new UsernamePasswordAuthenticationToken(
-                    userDetails.getUsername(), "", userDetails.getAuthorities()
+                    userDetails, "", userDetails.getAuthorities()
             );
         }
         else
         {
             UserDetails userDetails = sellerService.loadUserByUsername(email);
             return new UsernamePasswordAuthenticationToken(
-                    userDetails.getUsername(), "", userDetails.getAuthorities()
+                    userDetails, "", userDetails.getAuthorities()
             );
         }
     }

--- a/userApi/src/main/java/com/zerobase/userApi/security/customer/CustomerDetails.java
+++ b/userApi/src/main/java/com/zerobase/userApi/security/customer/CustomerDetails.java
@@ -21,15 +21,18 @@ public class CustomerDetails implements UserDetails {
                 .collect(Collectors.toList());
     }
 
+    public Long getId()
+    {
+        return customer.getId();
+    }
+
     @Override
     public String getPassword() {
         return customer.getPassword();
     }
 
     @Override
-    public String getUsername() {
-        return customer.getName();
-    }
+    public String getUsername() { return customer.getName(); }
 
     @Override
     public boolean isAccountNonExpired() {

--- a/userApi/src/main/java/com/zerobase/userApi/service/customer/CustomerBalanceHistoryService.java
+++ b/userApi/src/main/java/com/zerobase/userApi/service/customer/CustomerBalanceHistoryService.java
@@ -1,0 +1,53 @@
+package com.zerobase.userApi.service.customer;
+
+import com.zerobase.userApi.domain.customer.CustomerBalanceHistory;
+import com.zerobase.userApi.dto.ChangeBalanceDto;
+import com.zerobase.userApi.exception.CustomException;
+import com.zerobase.userApi.exception.ErrorCode;
+import com.zerobase.userApi.repository.customer.CustomerBalanceHistoryRepository;
+import com.zerobase.userApi.repository.customer.CustomerRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class CustomerBalanceHistoryService {
+    private final CustomerBalanceHistoryRepository customerBalanceHistoryRepository;
+    private final CustomerRepository customerRepository;
+
+    // 오류에 대해 수행된 트랜잭션 기록
+    @Transactional(noRollbackFor = {CustomException.class})
+    public CustomerBalanceHistory changeBalance(
+            Long customerId, ChangeBalanceDto.Input form
+    ) throws CustomException
+    {
+         CustomerBalanceHistory customerBalanceHistory =
+                 customerBalanceHistoryRepository.findByCustomerIdRecent(customerId)
+                         .orElse(CustomerBalanceHistory.builder()
+                                 .changeMoney(0)
+                                 .currentMoney(0)
+                                 .customer(
+                                         customerRepository.findById(customerId)
+                                                 .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND))
+                                 ).build());
+
+         if(customerBalanceHistory.getCurrentMoney() + form.getMoney() < 0)
+         {
+             throw new CustomException(ErrorCode.NOT_ENOUGH_BALANCE);
+         }
+
+         customerBalanceHistory = CustomerBalanceHistory.builder()
+                 .changeMoney(customerBalanceHistory.getChangeMoney() + form.getMoney())
+                 .currentMoney(customerBalanceHistory.getCurrentMoney())
+                 .description(form.getMessage())
+                 .fromMessage(form.getFrom())
+                 .customer(customerBalanceHistory.getCustomer())
+                 .build();
+
+         customerBalanceHistoryRepository.save(customerBalanceHistory);
+         customerBalanceHistory.getCustomer().setBalance(customerBalanceHistory.getChangeMoney());
+
+         return customerBalanceHistory;
+    }
+}


### PR DESCRIPTION
1. customer 엔티티에 예치금 관련 컬럼 (balance) 추가
2. 예치금 관련 기록을 저장할 customerBalanceHistory 엔티티 생성
3. jpql 쿼리를 통해 해당 customer에 대한 최근의 예치금을 가져오는 HistoryRepository 구현
4. 예치금 기록을 저장 및 customer 예치금을 관리하는 customerBalanceHistory 서비스 구현
5. 예치금을 저축(save)하는 customer controller 구현