### PR TITLE
장바구니 추가 기능 및 테스트 코드 작성

### DIFF
--- a/orderApi/src/main/java/com/zerobase/orderApi/config/RedisConfig.java
+++ b/orderApi/src/main/java/com/zerobase/orderApi/config/RedisConfig.java
@@ -1,8 +1,11 @@
 package com.zerobase.orderApi.config;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
@@ -10,6 +13,18 @@ import org.springframework.data.redis.serializer.StringRedisSerializer;
 @Configuration
 @EnableRedisRepositories
 public class RedisConfig {
+
+    @Value("${spring.redis.host}")
+    private String redisHost;
+    @Value("${spring.redis.port}")
+    private int redisPort;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory()
+    {
+        return new LettuceConnectionFactory(redisHost, redisPort);
+    }
+
     @Bean
     public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory redisConnectionFactory)
     {

--- a/orderApi/src/main/java/com/zerobase/orderApi/controller/CustomerCartController.java
+++ b/orderApi/src/main/java/com/zerobase/orderApi/controller/CustomerCartController.java
@@ -1,0 +1,35 @@
+package com.zerobase.orderApi.controller;
+
+import com.zerobase.orderApi.domain.Cart;
+import com.zerobase.orderApi.dto.AddProductCartForm;
+import com.zerobase.orderApi.security.CustomUserDetails;
+import com.zerobase.orderApi.service.CartService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/customer/cart")
+public class CustomerCartController {
+    private final CartService cartService;
+
+    @PreAuthorize("hasRole('CUSTOMER')")
+    @PostMapping
+    public ResponseEntity<Cart> addCart(
+            @RequestBody AddProductCartForm form
+    ){
+        CustomUserDetails userDetails =
+                (CustomUserDetails) SecurityContextHolder
+                        .getContext()
+                        .getAuthentication()
+                        .getPrincipal();
+
+        return ResponseEntity.ok(cartService.addCart(userDetails.getId(), form));
+    }
+}

--- a/orderApi/src/main/java/com/zerobase/orderApi/domain/Cart.java
+++ b/orderApi/src/main/java/com/zerobase/orderApi/domain/Cart.java
@@ -1,0 +1,47 @@
+package com.zerobase.orderApi.domain;
+
+import jakarta.persistence.Id;
+import lombok.*;
+import org.springframework.data.redis.core.RedisHash;
+
+import java.util.List;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@RedisHash("cart")
+public class Cart {
+    @Id
+    private Long customerId;
+    private List<Product> productList;
+    private List<String> messages;
+
+    public void addMessage(String message)
+    {
+        messages.add(message);
+    }
+
+    @Data
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+        public static class Product{
+        private Long id;
+        private Long sellerId;
+        private String name;
+        private String description;
+        private List<ProductItem> productItemList;
+    }
+
+    @Data
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ProductItem{
+        private Long id;
+        private String name;
+        private Integer count;
+        private Integer price;
+    }
+}

--- a/orderApi/src/main/java/com/zerobase/orderApi/dto/AddProductCartForm.java
+++ b/orderApi/src/main/java/com/zerobase/orderApi/dto/AddProductCartForm.java
@@ -1,0 +1,37 @@
+package com.zerobase.orderApi.dto;
+
+import com.zerobase.orderApi.domain.Cart;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class AddProductCartForm {
+    private Long id;
+    private Long sellerId;
+    private String name;
+    private String description;
+    private List<ProductItemDto> productItemList;
+
+    public Cart.Product toProductRedisEntity()
+    {
+        return Cart.Product.builder()
+                .id(this.id)
+                .sellerId(this.sellerId)
+                .name(this.name)
+                .description(this.description)
+                .productItemList(
+                        this.getProductItemList().stream()
+                                .map(ProductItemDto::toProductItemRedisEntity)
+                                .collect(Collectors.toList())
+                )
+                .build();
+    }
+}

--- a/orderApi/src/main/java/com/zerobase/orderApi/dto/ProductItemDto.java
+++ b/orderApi/src/main/java/com/zerobase/orderApi/dto/ProductItemDto.java
@@ -1,5 +1,6 @@
 package com.zerobase.orderApi.dto;
 
+import com.zerobase.orderApi.domain.Cart;
 import com.zerobase.orderApi.domain.ProductItem;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -23,6 +24,18 @@ public class ProductItemDto {
                 .name(item.getName())
                 .price(item.getPrice())
                 .count(item.getCount())
+                .build();
+    }
+
+    public static Cart.ProductItem toProductItemRedisEntity(
+            ProductItemDto productItemDto
+    )
+    {
+        return Cart.ProductItem.builder()
+                .id(productItemDto.getId())
+                .name(productItemDto.getName())
+                .price(productItemDto.getPrice())
+                .count(productItemDto.getCount())
                 .build();
     }
 }

--- a/orderApi/src/main/java/com/zerobase/orderApi/exception/ErrorCode.java
+++ b/orderApi/src/main/java/com/zerobase/orderApi/exception/ErrorCode.java
@@ -9,7 +9,10 @@ import org.springframework.http.HttpStatus;
 public enum ErrorCode {
     PRODUCT_NOT_FOUND(HttpStatus.BAD_REQUEST, "해당하는 상품을 찾을 수 없습니다."),
     PRODUCT_ITEM_EXIST(HttpStatus.BAD_REQUEST, "같은 이름의 아이템이 이미 존재합니다."),
-    PRODUCT_ITEM_NOT_FOUND(HttpStatus.BAD_REQUEST, "해당하는 아이템을 찾을 수 없습니다.");
+    PRODUCT_ITEM_NOT_FOUND(HttpStatus.BAD_REQUEST, "해당하는 아이템을 찾을 수 없습니다."),
+
+    CART_CHANGE_FAILED(HttpStatus.BAD_REQUEST, "장바구니를 수정하는데 실패하였습니다."),
+    NOT_ENOUGH_ITEM_COUNT(HttpStatus.BAD_REQUEST, "상품 아이템의 수량이 부족합니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/orderApi/src/main/java/com/zerobase/orderApi/service/CartService.java
+++ b/orderApi/src/main/java/com/zerobase/orderApi/service/CartService.java
@@ -1,0 +1,136 @@
+package com.zerobase.orderApi.service;
+
+import com.zerobase.orderApi.domain.Cart;
+import com.zerobase.orderApi.domain.Product;
+import com.zerobase.orderApi.domain.ProductItem;
+import com.zerobase.orderApi.dto.AddProductCartForm;
+import com.zerobase.orderApi.dto.ProductItemDto;
+import com.zerobase.orderApi.exception.CustomException;
+import com.zerobase.orderApi.exception.ErrorCode;
+import com.zerobase.orderApi.repository.ProductRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class CartService {
+
+    private final RedisClientService redisClientService;
+    private final ProductRepository productRepository;
+
+    public Cart addCart(Long customerId, AddProductCartForm form)
+    {
+        Cart cart = redisClientService.get(customerId, Cart.class);
+
+        validateForm(cart, form);
+
+        if(cart == null)
+        {
+            cart = new Cart();
+            cart.setCustomerId(customerId);
+            cart.setProductList(new ArrayList<>());
+            cart.setMessages(new ArrayList<>());
+        }
+
+        Optional<Cart.Product> productOptional =
+                cart.getProductList().stream()
+                .filter(product -> product.getId().equals(form.getId()))
+                .findFirst();
+
+        if(productOptional.isPresent())
+        {
+            Cart.Product redisProduct = productOptional.get();
+
+            List<Cart.ProductItem> productItemList =
+                    form.getProductItemList().stream()
+                            .map(ProductItemDto::toProductItemRedisEntity)
+                            .collect(Collectors.toList());
+
+            // productItem ID로 장바구니에 있는 productItem 객체를 가져오기 위함
+            Map<Long, Cart.ProductItem> redisItemMap =
+                    redisProduct.getProductItemList().stream()
+                            .collect(Collectors.toMap(Cart.ProductItem::getId, it -> it));
+
+
+            // 이름이 일치하지 않을 때
+            if(!redisProduct.getName().equals(form.getName()))
+            {
+                cart.addMessage("상품 이름이 일치하지 않습니다. 확인 요망");
+            }
+            for(Cart.ProductItem item : productItemList)
+            {
+                Cart.ProductItem redisItem =
+                        redisItemMap.getOrDefault(item.getId(), null);
+
+                if(redisItem == null)
+                {
+                    redisProduct.getProductItemList().add(item);
+                }
+                else
+                {
+                    // 가격이 일치하지 않을 때
+                    if(redisItem.getPrice() != item.getPrice())
+                    {
+                        cart.addMessage(
+                                redisItem.getName() + "의 가격이 일치하지 않습니다. 확인 요망"
+                        );
+                        redisItem.setCount(redisItem.getCount() + item.getCount());
+                    }
+                }
+            }
+        }
+        else
+        {
+            Cart.Product product = form.toProductRedisEntity();
+            cart.getProductList().add(product);
+        }
+
+        redisClientService.put(customerId, cart);
+        return cart;
+    }
+
+    private void validateForm(Cart cart, AddProductCartForm form)
+    {
+        Product product = productRepository.findById(form.getId())
+                .orElseThrow(() -> new CustomException(ErrorCode.PRODUCT_NOT_FOUND));
+
+        // 상품 아이템의 수량 검증
+        if(cart != null)
+        {
+            // 장바구니에 존재하는 상품 확인
+            Cart.Product cartProduct = cart.getProductList().stream()
+                    .filter(p -> p.getId().equals(form.getId()))
+                    .findFirst()
+                    .orElse(null);
+
+            // seller가 등록한 item count를 얻어오는 map 생성
+            Map<Long, Integer> currentItemCntMap = product.getProductItemList().stream()
+                    .collect(Collectors.toMap(ProductItem::getId, ProductItem::getCount));
+
+            // 장바구니에 존재하는 상품의 item count를 얻어오는 map 생성
+            Map<Long, Integer> cartItemCntMap =
+                    cartProduct == null ? null : cartProduct.getProductItemList().stream()
+                    .collect(Collectors.toMap(Cart.ProductItem::getId, Cart.ProductItem::getCount));
+
+            // 수량 검증
+            form.getProductItemList().stream().forEach(
+                    formItem -> {
+                        Integer cartItemCnt = cartItemCntMap == null ?
+                                0 : cartItemCntMap.getOrDefault(formItem.getId(), 0);
+                        Integer currentItemCnt = currentItemCntMap.get(formItem.getId());
+
+                        if(cartItemCnt + formItem.getCount() > currentItemCnt)
+                            throw new CustomException(ErrorCode.NOT_ENOUGH_ITEM_COUNT);
+                    }
+            );
+        }
+    }
+}

--- a/orderApi/src/main/java/com/zerobase/orderApi/service/RedisClientService.java
+++ b/orderApi/src/main/java/com/zerobase/orderApi/service/RedisClientService.java
@@ -1,0 +1,56 @@
+package com.zerobase.orderApi.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.zerobase.orderApi.domain.Cart;
+import com.zerobase.orderApi.exception.CustomException;
+import com.zerobase.orderApi.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.util.ObjectUtils;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class RedisClientService {
+
+    private final RedisTemplate<String, Object> redisTemplate;
+    private final ObjectMapper objectMapper;
+
+    public <T> T get(Long key, Class<T> classType)
+    {
+        return get(key.toString(), classType);
+    }
+
+    public <T> T get(String key, Class<T> classType)
+    {
+        String redisValue = (String) redisTemplate.opsForValue().get(key);
+        if(ObjectUtils.isEmpty(redisValue))
+        {
+            return null;
+        }
+        else {
+            try {
+                return objectMapper.readValue(redisValue, classType);
+            } catch (JsonProcessingException e) {
+                log.error("Parsing error", e);
+                return null;
+            }
+        }
+    }
+
+    public void put(Long key, Cart cart){
+        put(key.toString(), cart);
+    }
+
+    public void put(String key, Cart cart)
+    {
+        try{
+            redisTemplate.opsForValue().set(key, objectMapper.writeValueAsString(cart));
+        } catch (JsonProcessingException e) {
+            throw new CustomException(ErrorCode.CART_CHANGE_FAILED);
+        }
+    }
+}

--- a/orderApi/src/main/resources/application.yml
+++ b/orderApi/src/main/resources/application.yml
@@ -16,6 +16,6 @@ spring:
 #        dialect: org.hibernate.dialect.MySQLDialect
         format_sql: true
 
-#  redis:
-#    host: localhost
-#    port: 6379
+  redis:
+    host: localhost
+    port: 6379

--- a/orderApi/src/test/java/com/zerobase/orderApi/service/CartServiceTest.java
+++ b/orderApi/src/test/java/com/zerobase/orderApi/service/CartServiceTest.java
@@ -1,0 +1,172 @@
+package com.zerobase.orderApi.service;
+
+import com.zerobase.orderApi.domain.Cart;
+import com.zerobase.orderApi.domain.Product;
+import com.zerobase.orderApi.domain.ProductItem;
+import com.zerobase.orderApi.dto.AddProductCartForm;
+import com.zerobase.orderApi.dto.ProductItemDto;
+import com.zerobase.orderApi.repository.ProductRepository;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+public class CartServiceTest {
+
+    @Mock
+    private RedisClientService redisClientService;
+
+    @Mock
+    private ProductRepository productRepository;
+
+    @InjectMocks
+    private CartService cartService;
+
+    @BeforeEach
+    void init()
+    {
+        List<Cart.ProductItem> cartProductItemList = new ArrayList<>(
+                List.of(
+                    Cart.ProductItem.builder()
+                            .id(1L)
+                            .name("chocolate")
+                            .count(1)
+                            .price(5000)
+                            .build()
+                )
+        );
+
+        List<Cart.Product> cartProductList = new ArrayList<>(
+                List.of(
+                    Cart.Product.builder()
+                            .id(1L)
+                            .sellerId(1L)
+                            .name("james")
+                            .description("snacks")
+                            .productItemList(cartProductItemList)
+                            .build()
+                )
+        );
+
+        cartProductList.add(null);
+
+        given(redisClientService.get(anyLong(), any()))
+                .willReturn(
+                        Cart.builder()
+                            .customerId(1L)
+                            .productList(cartProductList)
+                            .messages(new ArrayList<>())
+                            .build()
+                );
+
+        List<ProductItem> productItemList = new ArrayList<>(
+                List.of(
+                    ProductItem.builder()
+                            .Id(1L)
+                            .sellerId(1L)
+                            .name("chocolate")
+                            .count(5)
+                            .price(5000)
+                            .build(),
+                    ProductItem.builder()
+                            .Id(2L)
+                            .sellerId(1L)
+                            .name("sweet chocolate")
+                            .count(5)
+                            .price(10000)
+                            .build(),
+                    ProductItem.builder()
+                            .Id(3L)
+                            .sellerId(1L)
+                            .name("sweeter chocolate")
+                            .count(5)
+                            .price(20000)
+                            .build(),
+                    ProductItem.builder()
+                            .Id(4L)
+                            .sellerId(1L)
+                            .name("sweetest chocolate")
+                            .count(5)
+                            .price(50000)
+                            .build()
+                )
+        );
+        Product product = Product.builder()
+                .id(1L)
+                .sellerId(1L)
+                .name("james")
+                .description("snacks")
+                .productItemList(new ArrayList<>())
+                .build();
+
+        productItemList.stream()
+                .forEach(it -> product.addProductItem(it));
+
+        given(productRepository.findById(anyLong()))
+                .willReturn(Optional.of(product));
+    }
+
+    @DisplayName("Cart 추가 성공")
+    @Test
+    void addCart()
+    {
+        //given
+        AddProductCartForm form = AddProductCartForm.builder()
+                .id(1L)
+                .sellerId(1L)
+                .name("james")
+                .description("snacks")
+                .productItemList(
+                        new ArrayList<>(
+                                List.of(
+                                    ProductItemDto.builder()
+                                            .name("chocolate")
+                                            .id(1L)
+                                            .price(5000)
+                                            .count(2)
+                                            .build(),
+                                    ProductItemDto.builder()
+                                            .name("sweet chocolate")
+                                            .id(2L)
+                                            .price(10000)
+                                            .count(1)
+                                            .build()
+                                )
+                        )
+                ).build();
+
+        ArgumentCaptor<Cart> cartArgumentCaptor = ArgumentCaptor.forClass(Cart.class);
+
+        cartService.addCart(1L, form);
+
+        verify(redisClientService, times(1)).put(anyLong(), cartArgumentCaptor.capture());
+        Cart capturedCart = cartArgumentCaptor.getValue();
+
+        Assertions.assertTrue(
+                capturedCart.getProductList().get(0)
+                    .getProductItemList().stream()
+                        .anyMatch(it -> "chocolate".equals(it.getName()) && it.getCount().equals(3))
+        );
+        Assertions.assertTrue(
+                capturedCart.getProductList().get(0)
+                    .getProductItemList().stream()
+                        .anyMatch(it -> "sweet chocolate".equals(it.getName()) && it.getCount().equals(1))
+        );
+    }
+}


### PR DESCRIPTION
1. 장바구니 검증
2-1. 장바구니 추가 시 구매하고자 하는 수량이 Seller가 등록한 수량보다 초과하는지를 검증

2. 장바구니 추가
2-1. redis의 키를 기반으로 object mapper를 이용한 장바구니 엔티티 set / get을 하는 RedisClient 서비스 구현
※ Redis DB를 사용하여 customerId를 key로 하는 장바구니 엔티티를 생성 및 저장 ( Object Mapper를 사용하여 String으로 저장 )
3-1. redis에서 장바구니를 가져오고, 해당하는 아이템이 이미 존재하면 수량만 증가 및 존재하지 않으면 아이템 추가 및 저장


3. 장바구니 추가 단위 테스트 코드 작성 ( Mock을 이용한 장바구니 추가 서비스에 대한 단위 테스트 구현 )