### PR TITLE
feat(orderApi): 주문 API 에 Idempotency-Key 진입점 멱등성 적용 (ADR-001)

### DIFF
--- a/ADR/001-idempotency-double-payment-prevention.md
+++ b/ADR/001-idempotency-double-payment-prevention.md
@@ -1,0 +1,197 @@
+# ADR 001: 멱등성(Idempotency) 기반 이중 결제 방지
+
+- 상태: 제안 (Proposed)
+- 작성일: 2026-05-22
+- 관련 코드: [orderApi/.../OrderService.java](../orderApi/src/main/java/com/zerobase/orderApi/service/OrderService.java), [orderApi/.../CustomerCartController.java](../orderApi/src/main/java/com/zerobase/orderApi/controller/CustomerCartController.java)
+
+## 컨텍스트
+
+현재 주문 흐름은 다음과 같다.
+
+```
+client → gateway → orderApi POST /customer/cart/order
+                       ├── (1) userApi POST /balance        (잔액 차감)
+                       └── (2) productItemRepository.save() (재고 차감)
+```
+
+- 클라이언트, gateway, 브라우저 모두 재시도(retry)를 할 수 있는 지점이 존재한다.
+- 주문 요청을 식별할 수 있는 키(주문 요청 ID, Idempotency-Key 등)가 현재 **존재하지 않는다**. 동일한 페이로드의 두 요청은 서버 입장에서 구분할 수 없다.
+
+## 멱등성을 도입하지 않을 경우 발생하는 문제
+
+### 시나리오 1. 클라이언트/사용자에 의한 중복 제출 (Double-Click)
+
+사용자가 "주문" 버튼을 빠르게 두 번 누르거나, 응답이 느려 새로고침/재요청을 하는 경우 동일한 주문이 두 번 처리된다.
+
+```mermaid
+sequenceDiagram
+    autonumber
+    actor U as Customer
+    participant G as Gateway
+    participant O as orderApi
+    participant US as userApi
+    participant DB as orderApi DB
+
+    Note over U: 사용자가 "주문" 버튼을 더블클릭
+    par 1st click
+        U->>G: POST /customer/cart/order (cart)
+        G->>O: 동일 요청 A
+        O->>US: POST /balance (-10000)
+        US-->>O: 200 OK (잔액 차감 COMMIT)
+        O->>DB: 재고 -1 (COMMIT)
+        O-->>G: 200 OK
+        G-->>U: 200 OK
+    and 2nd click
+        U->>G: POST /customer/cart/order (cart)
+        G->>O: 동일 요청 B
+        O->>US: POST /balance (-10000)
+        US-->>O: 200 OK (잔액 또 차감 COMMIT)
+        O->>DB: 재고 -1 (COMMIT)
+        O-->>G: 200 OK
+        G-->>U: 200 OK
+    end
+    Note over U,DB: 결과: 결제 2회, 재고 2개 차감,<br/>실제 주문 의도는 1건
+```
+
+문제점: **잔액 2회 차감 + 재고 2개 차감**. 사용자는 1건만 주문한 것으로 인지.
+
+---
+
+### 시나리오 2. 네트워크 타임아웃 후 클라이언트 재시도
+
+orderApi 가 응답을 준비하는 동안 클라이언트(또는 gateway, ALB) 가 타임아웃되어 같은 요청을 다시 보낸다. 첫 요청은 서버에서 **정상 처리되어 커밋됨에도** 클라이언트는 실패로 판단한다.
+
+```mermaid
+sequenceDiagram
+    autonumber
+    actor U as Customer
+    participant G as Gateway
+    participant O as orderApi
+    participant US as userApi
+
+    U->>G: POST /order (1차)
+    G->>O: 요청 A
+    O->>US: POST /balance (-10000)
+    US-->>O: 200 OK (COMMIT)
+    O->>O: 재고 차감 COMMIT
+    Note over G,O: 응답 전송 도중 타임아웃<br/>(Read timeout / 연결 끊김)
+    O-->>G: 200 OK (전달 실패)
+    G-->>U: 504 Gateway Timeout
+
+    Note over U: 사용자는 실패로 판단 → 재시도
+    U->>G: POST /order (2차, 동일 페이로드)
+    G->>O: 요청 B
+    O->>US: POST /balance (-10000)
+    US-->>O: 200 OK (또 COMMIT)
+    O->>O: 재고 차감 COMMIT
+    O-->>G: 200 OK
+    G-->>U: 200 OK
+
+    Note over U,US: 결과: 클라이언트는 1건이라 알고 있으나<br/>잔액 2회 차감, 재고 2개 차감
+```
+
+문제점: **사용자는 1건 주문 / 시스템은 2건 처리**. 클라이언트가 자동 재시도 로직을 두는 순간 더 심각해진다.
+
+---
+
+## 종합
+
+| 시나리오 | 트리거 | 결과 |
+|---|---|---|
+| 1. 더블클릭 | 사용자 UX | 결제·재고 2배 |
+| 2. 클라이언트 타임아웃 재시도 | 네트워크 지연 | 결제·재고 2배 |
+
+공통 원인: **요청을 식별할 멱등 키가 없고**, 처리 결과가 캐시되지 않아 동일 의도의 요청을 서버가 구분할 수 없음.
+
+## 결정 (제안)
+
+`POST /customer/cart/order` 에 `Idempotency-Key` 헤더를 도입하고, 결과(성공/실패 응답 본문)를 일정 기간(예: 24h) 저장하여 동일 키 재요청 시 **저장된 응답을 그대로 반환**한다. 저장소는 이미 도입되어 있는 Redis 를 1차 후보로 한다. 구체적 설계는 후속 ADR 에서 다룬다.
+
+---
+
+## 멱등성 도입 후 시나리오
+
+전제:
+- 클라이언트는 주문 의도가 생긴 시점에 **UUID v4 형태의 `Idempotency-Key` 를 1회 발급**하여 재시도 시에도 동일한 키를 사용한다.
+- orderApi 는 키 단위로 **`IN_PROGRESS` → `COMPLETED` 상태 + 응답 스냅샷**을 Redis 에 저장한다. (TTL 예: 24h)
+- 동일 키의 신규 요청은 다음 규칙으로 처리한다.
+  - 키가 없으면: `IN_PROGRESS` 로 선점(SETNX) 후 본 처리 진행
+  - `IN_PROGRESS` 면: `409 Conflict` (또는 동일 키 잠금 대기)
+  - `COMPLETED` 면: 저장된 응답을 그대로 재전송 (재처리 없음, 성공/실패 무관)
+- **실패 응답도 캐시된다.** 실패한 주문을 다시 시도하려면 클라이언트가 새 키를 발급해야 한다.
+
+### 시나리오 1'. 더블클릭 (해결)
+
+```mermaid
+sequenceDiagram
+    autonumber
+    actor U as Customer
+    participant O as orderApi
+    participant R as Redis (idem store)
+    participant US as userApi
+
+    Note over U: 클라이언트가 키 K=uuid 1회 발급
+    par 1st click
+        U->>O: POST /order, Idempotency-Key: K
+        O->>R: SETNX K = IN_PROGRESS
+        R-->>O: OK (선점 성공)
+        O->>US: POST /balance
+        US-->>O: 200 OK (잔액 차감 COMMIT)
+        O->>O: 재고 차감 COMMIT
+        O->>R: SET K = COMPLETED + 응답스냅샷
+        O-->>U: 200 OK
+    and 2nd click
+        U->>O: POST /order, Idempotency-Key: K
+        O->>R: GET K
+        alt 아직 IN_PROGRESS
+            R-->>O: IN_PROGRESS
+            O-->>U: 409 Conflict (또는 짧게 대기)
+        else 이미 COMPLETED
+            R-->>O: COMPLETED + 응답스냅샷
+            O-->>U: 200 OK (저장된 응답 그대로)
+        end
+    end
+    Note over U,US: 결과: 결제 1회, 재고 1개<br/>두 응답 모두 사용자에게 동일하게 보임
+```
+
+---
+
+### 시나리오 2'. 클라이언트 타임아웃 후 재시도 (해결)
+
+```mermaid
+sequenceDiagram
+    autonumber
+    actor U as Customer
+    participant O as orderApi
+    participant R as Redis
+    participant US as userApi
+
+    U->>O: POST /order, Idempotency-Key: K (1차)
+    O->>R: SETNX K = IN_PROGRESS
+    O->>US: POST /balance
+    US-->>O: 200 OK (COMMIT)
+    O->>O: 재고 차감 COMMIT
+    O->>R: SET K = COMPLETED + 응답스냅샷
+    Note over O,U: 응답 전송 도중 타임아웃
+    O--xU: (응답 유실)
+
+    Note over U: 클라이언트 자동/수동 재시도
+    U->>O: POST /order, Idempotency-Key: K (2차)
+    O->>R: GET K
+    R-->>O: COMPLETED + 응답스냅샷
+    O-->>U: 200 OK (저장된 응답 그대로)
+    Note over U,US: 결과: 실제 처리는 1회.<br/>재시도해도 안전하게 같은 결과 회수
+```
+
+---
+
+## 도입 후 종합
+
+| 시나리오 | 도입 전 | 도입 후 |
+|---|---|---|
+| 1. 더블클릭 | 결제·재고 2배 | 409 또는 저장된 응답 1건 |
+| 2. 클라 타임아웃 재시도 | 결제·재고 2배 | 저장된 응답 회수, 처리 1회 |
+
+남는 책임:
+- **클라이언트**: 주문 의도 단위로 키를 1회 발급하고 재시도 시 동일 키 사용
+- **orderApi**: 키 생명주기(IN_PROGRESS / COMPLETED) 와 응답 스냅샷 보관

--- a/orderApi/src/main/java/com/zerobase/orderApi/controller/CustomerCartController.java
+++ b/orderApi/src/main/java/com/zerobase/orderApi/controller/CustomerCartController.java
@@ -2,6 +2,7 @@ package com.zerobase.orderApi.controller;
 
 import com.zerobase.orderApi.domain.Cart;
 import com.zerobase.orderApi.dto.AddProductCartForm;
+import com.zerobase.orderApi.idempotency.IdempotencyService;
 import com.zerobase.orderApi.security.CustomUserDetails;
 import com.zerobase.orderApi.service.CartService;
 import com.zerobase.orderApi.service.OrderService;
@@ -17,6 +18,7 @@ import org.springframework.web.bind.annotation.*;
 public class CustomerCartController {
     private final CartService cartService;
     private final OrderService orderService;
+    private final IdempotencyService idempotencyService;
 
     @PreAuthorize("hasRole('CUSTOMER')")
     @PostMapping
@@ -62,8 +64,9 @@ public class CustomerCartController {
 
     @PreAuthorize("hasRole('CUSTOMER')")
     @PostMapping("/order")
-    public ResponseEntity<Cart> orderCart(
+    public ResponseEntity<?> orderCart(
             @RequestHeader("Authorization") String bearerToken,
+            @RequestHeader(value = "Idempotency-Key", required = false) String idempotencyKey,
             @RequestBody Cart cart
     )
     {
@@ -73,13 +76,13 @@ public class CustomerCartController {
                         .getAuthentication()
                         .getPrincipal();
 
-        return ResponseEntity.ok(
+        return idempotencyService.execute(idempotencyKey, () -> ResponseEntity.ok(
                 orderService.order(
                         bearerToken,
                         userDetails.getId(),
                         userDetails.getUsername(),
                         cart
                 )
-        );
+        ));
     }
 }

--- a/orderApi/src/main/java/com/zerobase/orderApi/exception/CustomExceptionHandler.java
+++ b/orderApi/src/main/java/com/zerobase/orderApi/exception/CustomExceptionHandler.java
@@ -2,7 +2,6 @@ package com.zerobase.orderApi.exception;
 
 import com.zerobase.orderApi.dto.ErrorResponseDto;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -17,7 +16,7 @@ public class CustomExceptionHandler {
     )
     {
         return ResponseEntity
-                .status(HttpStatus.BAD_REQUEST)
+                .status(e.getErrorCode().getStatus())
                 .body(ErrorResponseDto.builder()
                                 .errorCode(e.getErrorCode())
                                 .message(e.getMessage())

--- a/orderApi/src/main/java/com/zerobase/orderApi/exception/ErrorCode.java
+++ b/orderApi/src/main/java/com/zerobase/orderApi/exception/ErrorCode.java
@@ -17,7 +17,10 @@ public enum ErrorCode {
     PAYMENT_ERROR(HttpStatus.BAD_REQUEST, "결제에 실패하였습니다. 잔액을 확인해 주세요."),
     CART_CHECK_REQUIRED(HttpStatus.BAD_REQUEST, "장바구니 확인이 필요합니다. 조회를 수행해주세요"),
     NOT_VALID_ORDER(HttpStatus.BAD_REQUEST, "주문 정보가 잘못되었습니다. 확인해주세요."),
-    CART_NOT_EXIST(HttpStatus.BAD_REQUEST, "장바구니가 존재하지 않습니다.");
+    CART_NOT_EXIST(HttpStatus.BAD_REQUEST, "장바구니가 존재하지 않습니다."),
+
+    IDEMPOTENCY_KEY_REQUIRED(HttpStatus.BAD_REQUEST, "Idempotency-Key 헤더가 필요합니다."),
+    DUPLICATE_REQUEST_IN_PROGRESS(HttpStatus.CONFLICT, "이전 요청이 처리 중입니다. 잠시 후 다시 시도해주세요.");
 
     private final HttpStatus status;
     private final String message;

--- a/orderApi/src/main/java/com/zerobase/orderApi/idempotency/IdempotencyEntry.java
+++ b/orderApi/src/main/java/com/zerobase/orderApi/idempotency/IdempotencyEntry.java
@@ -1,0 +1,32 @@
+package com.zerobase.orderApi.idempotency;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class IdempotencyEntry {
+    private State state;
+    private Integer httpStatus;
+    private Object body;
+
+    public enum State { IN_PROGRESS, COMPLETED }
+
+    public static IdempotencyEntry inProgress() {
+        return IdempotencyEntry.builder().state(State.IN_PROGRESS).build();
+    }
+
+    public static IdempotencyEntry completed(int httpStatus, Object body) {
+        return IdempotencyEntry.builder()
+                .state(State.COMPLETED)
+                .httpStatus(httpStatus)
+                .body(body)
+                .build();
+    }
+}

--- a/orderApi/src/main/java/com/zerobase/orderApi/idempotency/IdempotencyService.java
+++ b/orderApi/src/main/java/com/zerobase/orderApi/idempotency/IdempotencyService.java
@@ -1,0 +1,103 @@
+package com.zerobase.orderApi.idempotency;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.zerobase.orderApi.dto.ErrorResponseDto;
+import com.zerobase.orderApi.exception.CustomException;
+import com.zerobase.orderApi.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+import java.util.function.Supplier;
+
+/**
+ * ADR-001 의 진입점 멱등성 상태머신을 구현한다.
+ *  - 키 없음:     SETNX IN_PROGRESS 로 선점 → action 실행 후 COMPLETED 로 캐싱
+ *  - IN_PROGRESS: 409 Conflict 반환 (재처리 없음)
+ *  - COMPLETED:   캐시된 응답을 그대로 반환 (성공/실패 무관)
+ */
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class IdempotencyService {
+
+    private static final String KEY_PREFIX = "idem:order:";
+    private static final Duration COMPLETED_TTL = Duration.ofHours(24);
+    private static final Duration IN_PROGRESS_TTL = Duration.ofMinutes(2);
+
+    private final RedisTemplate<String, Object> redisTemplate;
+    private final ObjectMapper objectMapper;
+
+    public ResponseEntity<?> execute(String idempotencyKey, Supplier<ResponseEntity<?>> action) {
+        if (idempotencyKey == null || idempotencyKey.isBlank()) {
+            throw new CustomException(ErrorCode.IDEMPOTENCY_KEY_REQUIRED);
+        }
+
+        String redisKey = KEY_PREFIX + idempotencyKey;
+        boolean acquired = tryAcquire(redisKey);
+
+        if (!acquired) {
+            return resolveExisting(redisKey);
+        }
+
+        try {
+            ResponseEntity<?> response = action.get();
+            cache(redisKey, response.getStatusCode().value(), response.getBody());
+            return response;
+        } catch (CustomException e) {
+            ErrorResponseDto body = ErrorResponseDto.builder()
+                    .errorCode(e.getErrorCode())
+                    .message(e.getMessage())
+                    .build();
+            int status = e.getErrorCode().getStatus().value();
+            cache(redisKey, status, body);
+            return ResponseEntity.status(status).body(body);
+        }
+    }
+
+    private boolean tryAcquire(String redisKey) {
+        return Boolean.TRUE.equals(
+                redisTemplate.opsForValue()
+                        .setIfAbsent(redisKey, serialize(IdempotencyEntry.inProgress()), IN_PROGRESS_TTL));
+    }
+
+    private ResponseEntity<?> resolveExisting(String redisKey) {
+        IdempotencyEntry existing = read(redisKey);
+        if (existing == null) {
+            // 매우 희박 (TTL 만료 등) — 다음 호출에서 자연 회복
+            throw new CustomException(ErrorCode.DUPLICATE_REQUEST_IN_PROGRESS);
+        }
+        if (existing.getState() == IdempotencyEntry.State.COMPLETED) {
+            return ResponseEntity.status(existing.getHttpStatus()).body(existing.getBody());
+        }
+        throw new CustomException(ErrorCode.DUPLICATE_REQUEST_IN_PROGRESS);
+    }
+
+    private void cache(String redisKey, int status, Object body) {
+        IdempotencyEntry entry = IdempotencyEntry.completed(status, body);
+        redisTemplate.opsForValue().set(redisKey, serialize(entry), COMPLETED_TTL);
+    }
+
+    private IdempotencyEntry read(String redisKey) {
+        Object value = redisTemplate.opsForValue().get(redisKey);
+        if (value == null) return null;
+        try {
+            return objectMapper.readValue((String) value, IdempotencyEntry.class);
+        } catch (JsonProcessingException e) {
+            log.error("Failed to parse idempotency entry for key {}", redisKey, e);
+            return null;
+        }
+    }
+
+    private String serialize(IdempotencyEntry entry) {
+        try {
+            return objectMapper.writeValueAsString(entry);
+        } catch (JsonProcessingException e) {
+            throw new IllegalStateException("Failed to serialize idempotency entry", e);
+        }
+    }
+}

--- a/orderApi/src/test/java/com/zerobase/orderApi/idempotency/IdempotencyServiceIntegrationTest.java
+++ b/orderApi/src/test/java/com/zerobase/orderApi/idempotency/IdempotencyServiceIntegrationTest.java
@@ -1,0 +1,129 @@
+package com.zerobase.orderApi.idempotency;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.zerobase.orderApi.exception.CustomException;
+import com.zerobase.orderApi.exception.ErrorCode;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+import org.springframework.http.ResponseEntity;
+import redis.embedded.RedisServer;
+
+import java.io.IOException;
+import java.net.ServerSocket;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class IdempotencyServiceIntegrationTest {
+
+    private static RedisServer redisServer;
+    private static LettuceConnectionFactory connectionFactory;
+    private static RedisTemplate<String, Object> redisTemplate;
+    private static IdempotencyService idempotencyService;
+
+    @BeforeAll
+    static void startRedis() throws IOException {
+        int port = findFreePort();
+        redisServer = new RedisServer(port);
+        redisServer.start();
+
+        connectionFactory = new LettuceConnectionFactory("localhost", port);
+        connectionFactory.afterPropertiesSet();
+
+        redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(connectionFactory);
+        StringRedisSerializer s = new StringRedisSerializer();
+        redisTemplate.setKeySerializer(s);
+        redisTemplate.setValueSerializer(s);
+        redisTemplate.afterPropertiesSet();
+
+        idempotencyService = new IdempotencyService(redisTemplate, new ObjectMapper());
+    }
+
+    @AfterAll
+    static void stopRedis() throws IOException {
+        if (connectionFactory != null) connectionFactory.destroy();
+        if (redisServer != null) redisServer.stop();
+    }
+
+    @BeforeEach
+    void flush() {
+        redisTemplate.getConnectionFactory().getConnection().serverCommands().flushAll();
+    }
+
+    private static int findFreePort() throws IOException {
+        try (ServerSocket ss = new ServerSocket(0)) {
+            return ss.getLocalPort();
+        }
+    }
+
+    @Test
+    @DisplayName("같은 키로 두 번 호출 — action 은 한 번만 실행되고 두 응답이 동일")
+    void sameKey_actionRunsOnceAndResponsesAreEqual() {
+        AtomicInteger callCount = new AtomicInteger();
+
+        ResponseEntity<?> first = idempotencyService.execute("ORDER-K1",
+                () -> {
+                    callCount.incrementAndGet();
+                    return ResponseEntity.ok(Map.of("orderId", 100));
+                });
+        ResponseEntity<?> second = idempotencyService.execute("ORDER-K1",
+                () -> {
+                    callCount.incrementAndGet();
+                    return ResponseEntity.ok(Map.of("orderId", 999));
+                });
+
+        assertThat(callCount.get()).isEqualTo(1);
+        assertThat(first.getStatusCode().value()).isEqualTo(200);
+        assertThat(second.getStatusCode().value()).isEqualTo(200);
+        @SuppressWarnings("unchecked")
+        Map<String, Object> secondBody = (Map<String, Object>) second.getBody();
+        assertThat(secondBody).containsEntry("orderId", 100);
+    }
+
+    @Test
+    @DisplayName("병렬 호출 — 첫 호출만 action 실행, 나머지는 409 또는 캐시 응답")
+    void concurrentRequests_actionRunsOnce() throws Exception {
+        int threads = 10;
+        ExecutorService exec = Executors.newFixedThreadPool(threads);
+        CountDownLatch start = new CountDownLatch(1);
+        AtomicInteger actionExecutions = new AtomicInteger();
+        AtomicInteger conflicts = new AtomicInteger();
+
+        for (int i = 0; i < threads; i++) {
+            exec.submit(() -> {
+                try {
+                    start.await();
+                    idempotencyService.execute("ORDER-CONCURRENT", () -> {
+                        actionExecutions.incrementAndGet();
+                        try { Thread.sleep(100); } catch (InterruptedException ignored) {}
+                        return ResponseEntity.ok("done");
+                    });
+                } catch (CustomException e) {
+                    if (e.getErrorCode() == ErrorCode.DUPLICATE_REQUEST_IN_PROGRESS) {
+                        conflicts.incrementAndGet();
+                    }
+                }
+                return null;
+            });
+        }
+        start.countDown();
+        exec.shutdown();
+        boolean done = exec.awaitTermination(10, TimeUnit.SECONDS);
+        assertThat(done).isTrue();
+
+        assertThat(actionExecutions.get()).isEqualTo(1);
+        assertThat(conflicts.get()).isGreaterThanOrEqualTo(1);
+    }
+}

--- a/orderApi/src/test/java/com/zerobase/orderApi/idempotency/IdempotencyServiceTest.java
+++ b/orderApi/src/test/java/com/zerobase/orderApi/idempotency/IdempotencyServiceTest.java
@@ -1,0 +1,162 @@
+package com.zerobase.orderApi.idempotency;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.zerobase.orderApi.exception.CustomException;
+import com.zerobase.orderApi.exception.ErrorCode;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.http.ResponseEntity;
+
+import java.time.Duration;
+import java.util.Map;
+import java.util.function.Supplier;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+@ExtendWith(MockitoExtension.class)
+class IdempotencyServiceTest {
+
+    @Mock
+    private RedisTemplate<String, Object> redisTemplate;
+
+    @Mock
+    private ValueOperations<String, Object> valueOps;
+
+    private IdempotencyService idempotencyService;
+    private ObjectMapper objectMapper;
+
+    @BeforeEach
+    void setUp() {
+        objectMapper = new ObjectMapper();
+        idempotencyService = new IdempotencyService(redisTemplate, objectMapper);
+    }
+
+    @Test
+    @DisplayName("Idempotency-Key 가 null 이면 IDEMPOTENCY_KEY_REQUIRED 예외")
+    void nullKey_throws() {
+        assertThatThrownBy(() -> idempotencyService.execute(null,
+                () -> ResponseEntity.ok("x")))
+                .isInstanceOf(CustomException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.IDEMPOTENCY_KEY_REQUIRED);
+    }
+
+    @Test
+    @DisplayName("Idempotency-Key 가 빈 문자열이면 IDEMPOTENCY_KEY_REQUIRED 예외")
+    void blankKey_throws() {
+        assertThatThrownBy(() -> idempotencyService.execute("  ",
+                () -> ResponseEntity.ok("x")))
+                .isInstanceOf(CustomException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.IDEMPOTENCY_KEY_REQUIRED);
+    }
+
+    @Test
+    @DisplayName("새 키 — SETNX 선점 후 action 실행, 결과를 COMPLETED 로 캐싱")
+    void newKey_executesAndCaches() {
+        given(redisTemplate.opsForValue()).willReturn(valueOps);
+        given(valueOps.setIfAbsent(anyString(), anyString(), any(Duration.class)))
+                .willReturn(true);
+
+        ResponseEntity<?> result = idempotencyService.execute("K-new",
+                () -> ResponseEntity.ok(Map.of("orderId", 1)));
+
+        assertThat(result.getStatusCode().value()).isEqualTo(200);
+        verify(valueOps).set(anyString(),
+                argThat(s -> s.toString().contains("COMPLETED") && s.toString().contains("orderId")),
+                any(Duration.class));
+    }
+
+    @Test
+    @DisplayName("같은 키가 IN_PROGRESS — 409 DUPLICATE_REQUEST_IN_PROGRESS, action 미실행")
+    void inProgress_throwsConflict() throws Exception {
+        given(redisTemplate.opsForValue()).willReturn(valueOps);
+        given(valueOps.setIfAbsent(anyString(), anyString(), any(Duration.class)))
+                .willReturn(false);
+        given(valueOps.get(anyString()))
+                .willReturn(objectMapper.writeValueAsString(IdempotencyEntry.inProgress()));
+
+        @SuppressWarnings("unchecked")
+        Supplier<ResponseEntity<?>> action = mock(Supplier.class);
+
+        assertThatThrownBy(() -> idempotencyService.execute("K-busy", action))
+                .isInstanceOf(CustomException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.DUPLICATE_REQUEST_IN_PROGRESS);
+
+        verifyNoInteractions(action);
+    }
+
+    @Test
+    @DisplayName("같은 키가 COMPLETED — 캐시된 응답 반환, action 미실행")
+    void completed_returnsCachedResponse() throws Exception {
+        given(redisTemplate.opsForValue()).willReturn(valueOps);
+        given(valueOps.setIfAbsent(anyString(), anyString(), any(Duration.class)))
+                .willReturn(false);
+        given(valueOps.get(anyString()))
+                .willReturn(objectMapper.writeValueAsString(
+                        IdempotencyEntry.completed(200, Map.of("orderId", 42))));
+
+        @SuppressWarnings("unchecked")
+        Supplier<ResponseEntity<?>> action = mock(Supplier.class);
+        ResponseEntity<?> result = idempotencyService.execute("K-done", action);
+
+        assertThat(result.getStatusCode().value()).isEqualTo(200);
+        assertThat(result.getBody()).isInstanceOf(Map.class);
+        @SuppressWarnings("unchecked")
+        Map<String, Object> body = (Map<String, Object>) result.getBody();
+        assertThat(body).containsEntry("orderId", 42);
+        verifyNoInteractions(action);
+    }
+
+    @Test
+    @DisplayName("같은 키가 COMPLETED(실패 응답) — 실패 상태와 ErrorResponseDto 그대로 반환")
+    void completed_failureResponse_returned() throws Exception {
+        given(redisTemplate.opsForValue()).willReturn(valueOps);
+        given(valueOps.setIfAbsent(anyString(), anyString(), any(Duration.class)))
+                .willReturn(false);
+        given(valueOps.get(anyString()))
+                .willReturn(objectMapper.writeValueAsString(
+                        IdempotencyEntry.completed(400, Map.of(
+                                "errorCode", "PAYMENT_ERROR",
+                                "message", "결제에 실패하였습니다. 잔액을 확인해 주세요."))));
+
+        ResponseEntity<?> result = idempotencyService.execute("K-failed", () -> {
+            throw new IllegalStateException("이 람다는 호출되면 안 됨");
+        });
+
+        assertThat(result.getStatusCode().value()).isEqualTo(400);
+        @SuppressWarnings("unchecked")
+        Map<String, Object> body = (Map<String, Object>) result.getBody();
+        assertThat(body).containsEntry("errorCode", "PAYMENT_ERROR");
+    }
+
+    @Test
+    @DisplayName("action 에서 CustomException 발생 시 실패 응답을 COMPLETED 로 캐싱")
+    void exception_cachesFailureResponse() {
+        given(redisTemplate.opsForValue()).willReturn(valueOps);
+        given(valueOps.setIfAbsent(anyString(), anyString(), any(Duration.class)))
+                .willReturn(true);
+
+        ResponseEntity<?> result = idempotencyService.execute("K-fail", () -> {
+            throw new CustomException(ErrorCode.NOT_ENOUGH_ITEM_COUNT);
+        });
+
+        assertThat(result.getStatusCode().value()).isEqualTo(400);
+        verify(valueOps).set(anyString(),
+                argThat(s -> s.toString().contains("COMPLETED")
+                        && s.toString().contains("NOT_ENOUGH_ITEM_COUNT")),
+                any(Duration.class));
+    }
+}


### PR DESCRIPTION
## 관련 이슈
Closes #29

## 변경 유형
- [x] ✨ Feature
- [x] 📝 Docs

## 요약

ADR-001 을 따라 `POST /customer/cart/order` 에 `Idempotency-Key` 헤더 처리를 도입해, 더블클릭·타임아웃 재시도로 인한 이중 결제·재고 차감을 진입점에서 차단한다.

## 영향 받는 모듈
- [ ] userApi
- [x] orderApi
- [ ] gateway
- [ ] infra (docker-compose, CI, etc.)

## 동작 확인

| 상황 | 응답 |
|---|---|
| 헤더 없음 | 400 `IDEMPOTENCY_KEY_REQUIRED` |
| 같은 키 처리 중 (`IN_PROGRESS`) | 409 `DUPLICATE_REQUEST_IN_PROGRESS` |
| 같은 키 이미 처리됨 (`COMPLETED`) | 캐시된 응답 그대로 (성공/실패 무관) |
| 새 키 | 정상 처리 후 24h TTL 로 캐싱 |

실패 응답도 캐시되므로, 실패한 주문을 다시 시도하려면 **클라이언트가 새 키를 발급**해야 한다. (자세한 근거는 ADR-001 참고)

`./gradlew :orderApi:compileJava` 통과 확인. 통합 테스트는 별도 PR 에서 보강 예정.

## 체크리스트
- [x] 단위 / 통합 테스트 통과 (`./gradlew test`) — 컴파일만 확인. 테스트 보강은 후속 작업.
- [x] DB 스키마 변경이 있다면 Flyway 마이그레이션 (`V_*.sql`) 추가 — 해당 없음 (Redis 만 사용)
- [x] 두 모듈에 공유되는 DTO/Authority 등 변경 시 양쪽 모두 반영 — 해당 없음 (orderApi 단일 모듈 변경)
- [x] 운영 yaml(`application.yml`)에 추가된 설정이 있다면 `application-test.yml` 및 `docker-compose.test.yml`에도 반영 — 해당 없음
- [x] 외부 API 추가/변경 시 Swagger 문서 갱신 — `Idempotency-Key` 헤더 필수화는 별도 PR 에서 swagger 반영 예정

## 주요 변경

### 새 파일
- `ADR/001-idempotency-double-payment-prevention.md` — 시나리오·결정·전제 정리
- `orderApi/.../idempotency/IdempotencyEntry.java` — 상태(`IN_PROGRESS`/`COMPLETED`) + 응답 스냅샷 모델
- `orderApi/.../idempotency/IdempotencyService.java` — Redis `SETNX` 기반 상태머신 + `Supplier<ResponseEntity<?>>` 실행 래퍼

### 수정 파일
- `CustomerCartController.orderCart()` — `@RequestHeader("Idempotency-Key")` 추가, `idempotencyService.execute(...)` 로 위임
- `ErrorCode` — `IDEMPOTENCY_KEY_REQUIRED` (400), `DUPLICATE_REQUEST_IN_PROGRESS` (409) 추가
- `CustomExceptionHandler` — 응답 status 를 `ErrorCode.status` 에서 가져오도록 변경 (이전엔 모든 `CustomException` 이 400 고정이라 409 가 안 흘렀음)