### PR TITLE
feat: ADR-004 Transactional Outbox 패턴 적용

### DIFF
--- a/ADR/004-transactional-outbox-pattern.md
+++ b/ADR/004-transactional-outbox-pattern.md
@@ -1,0 +1,281 @@
+# ADR 004: Kafka 발행에 Transactional Outbox 패턴 적용
+
+- 상태: 제안 (Proposed)
+- 작성일: 2026-05-25
+- 관련 코드: [orderApi/.../OrderService.java](../orderApi/src/main/java/com/zerobase/orderApi/service/OrderService.java), [orderApi/.../SagaEventPublisher.java](../orderApi/src/main/java/com/zerobase/orderApi/saga/SagaEventPublisher.java)
+
+## 컨텍스트
+
+ADR-003 적용 후 `OrderService.order()` 는 한 메서드 안에서 두 가지 서로 다른 자원(DB, Kafka) 에 쓰기를 수행한다.
+
+```java
+@Transactional
+public OrderDto order(Long customerId, String username, Cart orderCart) {
+    ...
+    orderRepository.save(order);                       // (A) JPA INSERT, @Transactional 안
+    redisClientService.put(customerId, curCart);       // (B) Redis SET, 트랜잭션 밖
+    publisher.publish(SagaTopics.ORDER_CREATED, ...);  // (C) Kafka send, 트랜잭션 밖
+    return OrderDto.from(order);
+    // @Transactional 종료 시점에 (A) COMMIT
+}
+```
+
+- (A) 는 JPA 트랜잭션으로 묶이지만, (C) 의 Kafka publish 는 broker 와의 별도 통신이라 같은 트랜잭션에 포함될 수 없다 (Kafka 는 XA 분산 트랜잭션을 일반적으로 쓰지 않음).
+- 즉 **DB 에 Order 가 들어가는 것** 과 **Kafka 에 OrderCreated 가 들어가는 것** 이 서로 다른 시점·다른 자원에서 일어난다.
+- 이것이 분산 시스템의 고전적 **dual-write problem** 이다.
+
+## 현재 동기 발행 방식의 문제 시나리오
+
+### 시나리오 1. Kafka 발행은 됐는데 DB commit 이 실패
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant Ord as OrderService (@Transactional)
+    participant DB as orderApi DB
+    participant K as Kafka
+
+    Ord->>DB: INSERT Order (PENDING)
+    Note over DB: 트랜잭션 안, COMMIT 전
+    Ord->>K: publish OrderCreated
+    K-->>Ord: ack
+    Note over K: 이벤트 영속화됨
+    Note over Ord: 메서드 종료 → COMMIT 시도
+    DB--xOrd: COMMIT 실패 (deadlock, FK 위반, 연결 끊김)
+    Note over DB: Order INSERT 롤백
+    Note over Ord,K: 결과: Kafka 에 OrderCreated 있으나<br/>DB 에 Order 없음
+```
+
+문제점: 컨슈머가 `OrderCreated` 를 받아 처리하려고 `orderRepository.findById()` 를 하면 `ORDER_NOT_FOUND`. broker 가 재배달해도 같은 실패. 결국 poison message 가 된다.
+
+### 시나리오 2. Kafka 발행 후 commit 직전 JVM 종료
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant Ord as OrderService (@Transactional)
+    participant DB as orderApi DB
+    participant K as Kafka
+
+    Ord->>DB: INSERT Order (PENDING)
+    Ord->>K: publish OrderCreated
+    K-->>Ord: ack
+    Note over Ord: COMMIT 호출 직전<br/>OOMKill / SIGKILL / Pod evicted
+    Note over DB: 트랜잭션 abandoned →<br/>DB timeout 후 자동 ROLLBACK
+    Note over Ord,K: 결과: 시나리오 1 과 동일 — event 있음, Order 없음
+```
+
+문제점: JVM 이 비정상 종료되면 트랜잭션은 결국 롤백되지만 Kafka 발행은 이미 끝난 상태. 시나리오 1 과 같은 결과.
+
+### 시나리오 3. Kafka broker 일시 장애 시 이벤트 유실
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant Ord as OrderService
+    participant DB as orderApi DB
+    participant K as Kafka
+
+    Ord->>DB: INSERT Order
+    Ord->>K: publish OrderCreated
+    K--xOrd: TimeoutException / 연결 실패
+    Note over Ord: 예외 전파 → @Transactional 롤백
+    Note over DB: Order INSERT 롤백
+    Note over Ord: 사용자에게 500 반환
+    Note over Ord,K: 결과: 데이터 정합은 유지되지만<br/>일시 장애에 클라이언트 요청이 실패함
+```
+
+문제점: 이벤트 유실은 막혔지만 Kafka 가 잠깐만 흔들려도 사용자 요청이 실패. 비동기 패턴의 장점(브로커 영속화·재시도) 이 사라진다.
+
+## 종합 (현재 한계)
+
+| 시나리오 | 원인 | 결과 |
+|---|---|---|
+| 1. 발행 후 commit 실패 | DB lock / 네트워크 | event 있음, Order 없음 → poison message |
+| 2. 발행 후 JVM 종료 | OOMKill / SIGKILL | 시나리오 1 과 동일 |
+| 3. Kafka 일시 장애 | broker 다운 / 네트워크 | 사용자 요청 실패 |
+
+공통 원인: **DB 와 Kafka 가 서로 다른 트랜잭션 자원** 이라 두 쓰기를 원자적으로 묶을 수 없다. Kafka send 의 성공/실패와 DB commit 의 성공/실패가 일관되게 떨어지지 않는다.
+
+## 결정 (제안): Transactional Outbox Pattern
+
+이벤트 발행을 **두 단계로 분리** 한다.
+
+1. **저장 단계** (비즈니스 트랜잭션 안): Kafka 로 보내지 않고, 같은 DB 의 `outbox_events` 테이블에 INSERT. Order INSERT 와 outbox INSERT 가 **하나의 DB 트랜잭션** 으로 묶여 둘 다 commit 되거나 둘 다 롤백된다.
+2. **발행 단계** (별도 비동기 프로세스): 주기적으로 `outbox_events` 에서 미발행 row 를 읽어 Kafka 로 발행하고, 성공 시 `sent_at` 마킹.
+
+```mermaid
+sequenceDiagram
+    autonumber
+    actor Client as 클라이언트
+    participant Ord as OrderService
+    participant Pub as SagaEventPublisher
+    participant ODB as orderApi DB
+    participant Poll as OutboxPoller
+    participant K as Kafka
+    participant Cons as 컨슈머 (예 PaymentConsumer)
+    participant UDB as userApi DB
+
+    Note over Client,ODB: 단계 1: 비즈니스 트랜잭션 (동기 응답)
+
+    Client->>Ord: POST /customer/cart/order
+    Ord->>ODB: INSERT orders (PENDING)
+    Ord->>Pub: publish(ORDER_CREATED, event)
+    Pub->>ODB: INSERT outbox_events (eventId, topic, payload, sent_at=NULL)
+    Note over Ord,ODB: 두 INSERT 가 같은 @Transactional 안
+    Ord->>ODB: COMMIT (orders + outbox_events 동시 영속화)
+    Ord-->>Client: 200 OK (orderId, status=PENDING)
+
+    Note over ODB,K: 단계 2: 비동기 발행 (별도 폴러, 1초 주기)
+
+    Poll->>ODB: SELECT FROM outbox_events WHERE sent_at IS NULL ORDER BY created_at
+    ODB-->>Poll: 미발행 row (eventId, topic, payload)
+    Poll->>K: kafkaTemplate.send(topic, eventId, payload)
+    K-->>Poll: ack
+    Poll->>ODB: UPDATE outbox_events SET sent_at = now WHERE event_id = ?
+    Note over Poll,ODB: 마킹 실패 시 다음 주기에 같은 row 재발행 (at-least-once)
+
+    Note over K,UDB: 단계 3: 컨슈머 측 멱등성 (ADR-003 의 ProcessedEvent)
+
+    K->>Cons: deliver event (eventId 포함)
+    Cons->>UDB: SELECT processed_events WHERE event_id = ?
+    alt 처음 보는 eventId
+        Cons->>UDB: 비즈니스 처리 + INSERT processed_events
+        Cons-->>K: ack
+    else 이미 처리된 eventId (재배달 / 중복 발행)
+        Note over Cons: skip
+        Cons-->>K: ack
+    end
+```
+
+### 새 테이블
+
+```sql
+CREATE TABLE outbox_events (
+    event_id      VARCHAR(36)  NOT NULL,
+    topic         VARCHAR(100) NOT NULL,
+    payload       MEDIUMTEXT   NOT NULL,
+    created_at    DATETIME(6)  NOT NULL,
+    sent_at       DATETIME(6),
+    PRIMARY KEY (event_id),
+    INDEX idx_unsent (sent_at, created_at)
+) ENGINE = InnoDB;
+```
+
+- `event_id`: 발행자가 생성한 UUID. 그대로 페이로드 안의 `eventId` 가 되어 컨슈머의 `ProcessedEvent` 키와 일치 (ADR-003 의 멱등성과 자연스럽게 연결).
+- `idx_unsent`: 폴러가 `WHERE sent_at IS NULL ORDER BY created_at` 으로 빠르게 읽기 위함.
+
+## 적용 후 시나리오
+
+### 시나리오 1'. 발행(outbox INSERT) 후 commit 실패 → 같이 롤백
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant Ord as OrderService (@Transactional)
+    participant DB as orderApi DB
+
+    Ord->>DB: INSERT Order
+    Ord->>DB: INSERT outbox_events (eventId, payload)
+    Note over Ord: 메서드 종료 → COMMIT 시도
+    DB--xOrd: COMMIT 실패
+    Note over DB: Order 와 outbox 모두 ROLLBACK
+    Note over Ord,DB: 결과: Kafka 에 아무 것도 안 들어감. 깨끗한 실패.
+```
+
+문제 해결: 두 INSERT 가 같은 트랜잭션이라 같이 commit 또는 같이 롤백. **이벤트가 DB 상태와 일관되지 않을 가능성이 0**.
+
+### 시나리오 2'. commit 직후 JVM 종료
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant Ord as OrderService
+    participant DB as orderApi DB
+    participant Poll as OutboxPoller (다른 인스턴스 / 재시작 후)
+    participant K as Kafka
+
+    Ord->>DB: INSERT Order + INSERT outbox + COMMIT
+    Note over Ord: 즉시 JVM 종료
+    Note over DB: 데이터는 영속화됨<br/>outbox.sent_at = NULL
+    Note over Poll: 다른 노드 또는 재기동 후<br/>@Scheduled 가 동작
+    Poll->>DB: SELECT * FROM outbox WHERE sent_at IS NULL
+    DB-->>Poll: 미발행 row 반환
+    Poll->>K: send(topic, payload)
+    K-->>Poll: ack
+    Poll->>DB: UPDATE outbox SET sent_at = now
+    Note over Poll,K: 결과: 노드가 죽어도 이벤트는 결국 발행됨
+```
+
+문제 해결: outbox row 는 DB 에 안전히 영속화돼 있으므로, 어느 인스턴스든(또는 재시작된 같은 인스턴스든) 폴링 작업이 살아나면 미발행 row 를 읽어 Kafka 로 보낸다. **이벤트 유실 없음**.
+
+### 시나리오 3'. Kafka broker 일시 장애
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant Poll as OutboxPoller
+    participant DB as orderApi DB
+    participant K as Kafka
+
+    Poll->>DB: SELECT 미발행 outbox
+    DB-->>Poll: rows
+    Poll->>K: send
+    K--xPoll: TimeoutException (broker 다운)
+    Note over Poll: 예외 catch + log<br/>sent_at 마킹 skip
+    Note over Poll: 1초 후 다음 주기
+    Poll->>K: send (재시도)
+    K-->>Poll: ack (broker 복구)
+    Poll->>DB: UPDATE sent_at
+    Note over Poll,K: 결과: Kafka 가 잠시 흔들려도<br/>사용자 요청은 영향 없고 자동 복구
+```
+
+문제 해결: 발행 실패는 폴러 내부에서 catch 되어 다음 주기에 재시도. **사용자 요청 경로** (`POST /customer/cart/order`) 는 Kafka 상태와 분리되어 항상 빠르게 응답.
+
+### 시나리오 4'. 발행 후 sent 마킹 실패 → 중복 발행
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant Poll as OutboxPoller
+    participant DB as orderApi DB
+    participant K as Kafka
+    participant Cons as 컨슈머 (PaymentConsumer 등)
+
+    Poll->>K: send(eventId=X, payload)
+    K-->>Poll: ack
+    Note over Poll: UPDATE sent_at 직전 JVM 종료
+    Note over DB: outbox.sent_at = NULL 상태 유지
+    Note over Poll: 다른 인스턴스 또는 재시작
+    Poll->>DB: SELECT 미발행
+    DB-->>Poll: row(eventId=X) 그대로 반환
+    Poll->>K: send(eventId=X, payload) (중복)
+    K-->>Poll: ack
+    Poll->>DB: UPDATE sent_at
+    Note over Cons: Kafka 에 eventId=X 가 두 번 들어감
+    Cons->>DB: SELECT processed_events WHERE eventId=X
+    Note over Cons: 이미 존재 → 두 번째는 skip
+    Note over Poll,Cons: 결과: 컨슈머의 ProcessedEvent (ADR-003) 가<br/>중복 처리를 막아주므로 effectively-exactly-once
+```
+
+문제 해결: Outbox 는 **at-least-once 발행** 만 보장한다 (중복 발행은 일어날 수 있음). 단, 컨슈머 측에서 ADR-003 의 `ProcessedEvent` 가 같은 `eventId` 의 두 번째 도착을 skip 하므로 **결과적으로 정확히 한 번** 처리된다. Outbox + ProcessedEvent 가 짝을 이루어 end-to-end effectively-exactly-once 를 만든다.
+
+## 도입 후 종합
+
+| 시나리오 | 동기 발행 (현재) | Transactional Outbox |
+|---|---|---|
+| 1. 발행 후 commit 실패 | event 있음 / Order 없음 → poison | 둘 다 롤백 → 일관된 실패 |
+| 2. 발행 후 JVM 종료 | event 있음 / Order 없음 | outbox 가 영속화 → 다른 노드가 발행 |
+| 3. Kafka 장애 | 사용자 요청 실패 | 폴러만 영향, 사용자 요청은 정상 |
+| 4. 폴러의 sent 마킹 실패 | (없음 — 폴러 미존재) | 중복 발행, 그러나 `ProcessedEvent` 가 흡수 |
+
+요약: **DB commit 의 성공/실패가 곧 이벤트 발행의 성공/실패가 된다**. 두 자원에 걸친 dual-write 가 **한 자원(DB) 의 단일 commit** 으로 환원되어 정합성이 보장된다.
+
+## 남는 책임
+
+- **outbox_events 무한 증가** — sent_at 채워진 row 의 주기적 정리(예: 7일 이상 된 row 삭제) 가 필요. cron 또는 별도 스케줄러로 분리.
+- **폴러의 단일성 보장** — 여러 인스턴스가 동시에 폴링하면 중복 발행이 잦아진다 (ProcessedEvent 가 막아주긴 하지만 Kafka 부하 증가). 선택지:
+  - 단일 노드에서만 `@Scheduled` 실행 (배포 토폴로지로 보장)
+  - 분산 락 (예: Redis Redlock, ShedLock)
+  - `SELECT ... FOR UPDATE SKIP LOCKED` 로 DB 락 기반 분배
+- **`SagaEventPublisher.publish()` 의 트랜잭션 컨텍스트** — `Propagation.MANDATORY` 로 강제했으므로 호출자가 반드시 `@Transactional` 안이어야 한다. 그렇지 않으면 `IllegalTransactionStateException`. 단위 테스트 작성 시 주의.

--- a/orderApi/src/main/java/com/zerobase/orderApi/OrderApiApplication.java
+++ b/orderApi/src/main/java/com/zerobase/orderApi/OrderApiApplication.java
@@ -2,8 +2,10 @@ package com.zerobase.orderApi;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EnableScheduling
 public class OrderApiApplication {
 
     public static void main(String[] args) {

--- a/orderApi/src/main/java/com/zerobase/orderApi/saga/OutboxEvent.java
+++ b/orderApi/src/main/java/com/zerobase/orderApi/saga/OutboxEvent.java
@@ -1,0 +1,44 @@
+package com.zerobase.orderApi.saga;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.Instant;
+import java.util.UUID;
+
+/**
+ * Transactional Outbox (ADR-004) 의 발행 대기 row.
+ *  - 비즈니스 트랜잭션에서 INSERT 되어 같은 commit 으로 영속화된다.
+ *  - OutboxPoller 가 sent_at IS NULL 인 row 를 골라 Kafka 로 발행하고 sent_at 을 채운다.
+ */
+@Entity
+@Table(name = "outbox_events", indexes = {
+        @Index(name = "idx_unsent", columnList = "sent_at, created_at")
+})
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class OutboxEvent {
+
+    @Id
+    @Column(name = "event_id", length = 36)
+    private UUID eventId;
+
+    @Column(nullable = false, length = 100)
+    private String topic;
+
+    @Lob
+    @Column(nullable = false)
+    private String payload;
+
+    @Column(name = "created_at", nullable = false)
+    private Instant createdAt;
+
+    @Column(name = "sent_at")
+    private Instant sentAt;
+
+    public void markSent(Instant when) {
+        this.sentAt = when;
+    }
+}

--- a/orderApi/src/main/java/com/zerobase/orderApi/saga/OutboxEventRepository.java
+++ b/orderApi/src/main/java/com/zerobase/orderApi/saga/OutboxEventRepository.java
@@ -1,0 +1,10 @@
+package com.zerobase.orderApi.saga;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.UUID;
+
+public interface OutboxEventRepository extends JpaRepository<OutboxEvent, UUID> {
+    List<OutboxEvent> findTop100BySentAtIsNullOrderByCreatedAtAsc();
+}

--- a/orderApi/src/main/java/com/zerobase/orderApi/saga/OutboxPoller.java
+++ b/orderApi/src/main/java/com/zerobase/orderApi/saga/OutboxPoller.java
@@ -1,0 +1,49 @@
+package com.zerobase.orderApi.saga;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * ADR-004: outbox_events 의 미발행 row 를 주기적으로 Kafka 로 발행.
+ *  - 한 row 의 send + sent_at 마킹은 같은 @Transactional 안.
+ *  - 발행 실패 시 sent_at 미마킹 → 다음 주기 자동 재시도 (at-least-once).
+ *  - 순서 보장을 위해 한 건 실패 시 이후 row 도 보류.
+ */
+@Component
+@RequiredArgsConstructor
+@ConditionalOnProperty(name = "outbox.poller.enabled", havingValue = "true", matchIfMissing = true)
+@Slf4j
+public class OutboxPoller {
+
+    private static final Duration SEND_TIMEOUT = Duration.ofSeconds(3);
+
+    private final OutboxEventRepository outboxRepository;
+    private final KafkaTemplate<String, String> kafkaTemplate;
+
+    @Scheduled(fixedDelayString = "${outbox.poller.delay-ms:1000}")
+    @Transactional
+    public void publishPending() {
+        List<OutboxEvent> batch = outboxRepository.findTop100BySentAtIsNullOrderByCreatedAtAsc();
+        for (OutboxEvent row : batch) {
+            try {
+                kafkaTemplate.send(row.getTopic(), row.getEventId().toString(), row.getPayload())
+                        .get(SEND_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
+                row.markSent(Instant.now());
+            } catch (Exception e) {
+                log.warn("Failed to publish outbox event {} on topic {}: {}",
+                        row.getEventId(), row.getTopic(), e.getMessage());
+                break;
+            }
+        }
+    }
+}

--- a/orderApi/src/main/java/com/zerobase/orderApi/saga/SagaEventPublisher.java
+++ b/orderApi/src/main/java/com/zerobase/orderApi/saga/SagaEventPublisher.java
@@ -2,26 +2,42 @@ package com.zerobase.orderApi.saga;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.zerobase.orderApi.saga.event.SagaEvent;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
 
+import java.time.Instant;
+
+/**
+ * ADR-004: Kafka 로 직접 보내는 대신 outbox_events 테이블에 INSERT 만 한다.
+ * 호출자의 @Transactional 에 합류(MANDATORY) 해 비즈니스 row 와 같은 commit 단위로 묶인다.
+ * 실제 Kafka 발행은 OutboxPoller 가 비동기로 수행.
+ */
 @Component
 @RequiredArgsConstructor
 @Slf4j
 public class SagaEventPublisher {
 
-    private final KafkaTemplate<String, String> kafkaTemplate;
+    private final OutboxEventRepository outboxRepository;
     private final ObjectMapper objectMapper;
 
-    public void publish(String topic, Object event) {
+    @Transactional(propagation = Propagation.MANDATORY)
+    public void publish(String topic, SagaEvent event) {
+        String payload;
         try {
-            String payload = objectMapper.writeValueAsString(event);
-            kafkaTemplate.send(topic, payload);
-            log.info("Published event to {}: {}", topic, payload);
+            payload = objectMapper.writeValueAsString(event);
         } catch (JsonProcessingException e) {
             throw new IllegalStateException("Failed to serialize event for topic " + topic, e);
         }
+        outboxRepository.save(OutboxEvent.builder()
+                .eventId(event.getEventId())
+                .topic(topic)
+                .payload(payload)
+                .createdAt(Instant.now())
+                .build());
+        log.debug("Outbox enqueued: topic={} eventId={}", topic, event.getEventId());
     }
 }

--- a/orderApi/src/main/java/com/zerobase/orderApi/saga/event/SagaEvent.java
+++ b/orderApi/src/main/java/com/zerobase/orderApi/saga/event/SagaEvent.java
@@ -1,0 +1,13 @@
+package com.zerobase.orderApi.saga.event;
+
+import java.util.UUID;
+
+/**
+ * SAGA 이벤트의 공통 마커 인터페이스.
+ * 모든 이벤트는 발행자가 생성한 고유 UUID 를 노출해야 한다.
+ *
+ * - 발행 측(outbox row PK) 과 컨슈머 측(ProcessedEvent 멱등성 키) 에서 동일 UUID 를 공유한다.
+ */
+public interface SagaEvent {
+    UUID getEventId();
+}

--- a/orderApi/src/main/java/com/zerobase/orderApi/saga/event/SagaEvents.java
+++ b/orderApi/src/main/java/com/zerobase/orderApi/saga/event/SagaEvents.java
@@ -13,7 +13,7 @@ public class SagaEvents {
     @Builder
     @NoArgsConstructor
     @AllArgsConstructor
-    public static class OrderCreated {
+    public static class OrderCreated implements SagaEvent {
         private UUID eventId;
         private Long orderId;
         private Long customerId;
@@ -25,7 +25,7 @@ public class SagaEvents {
     @Builder
     @NoArgsConstructor
     @AllArgsConstructor
-    public static class PaymentDeducted {
+    public static class PaymentDeducted implements SagaEvent {
         private UUID eventId;
         private Long orderId;
     }
@@ -34,7 +34,7 @@ public class SagaEvents {
     @Builder
     @NoArgsConstructor
     @AllArgsConstructor
-    public static class PaymentFailed {
+    public static class PaymentFailed implements SagaEvent {
         private UUID eventId;
         private Long orderId;
         private String reason;
@@ -44,7 +44,7 @@ public class SagaEvents {
     @Builder
     @NoArgsConstructor
     @AllArgsConstructor
-    public static class StockReservationFailed {
+    public static class StockReservationFailed implements SagaEvent {
         private UUID eventId;
         private Long orderId;
         private Long customerId;
@@ -57,7 +57,7 @@ public class SagaEvents {
     @Builder
     @NoArgsConstructor
     @AllArgsConstructor
-    public static class PaymentReverted {
+    public static class PaymentReverted implements SagaEvent {
         private UUID eventId;
         private Long orderId;
     }

--- a/orderApi/src/main/resources/db/migration/V5__add_outbox_events.sql
+++ b/orderApi/src/main/resources/db/migration/V5__add_outbox_events.sql
@@ -1,0 +1,16 @@
+-- =============================================================================
+-- orderApi V5: Transactional Outbox (ADR-004) 발행 대기 테이블
+--  - 비즈니스 트랜잭션에서 INSERT 되어 같은 commit 단위로 영속화
+--  - OutboxPoller 가 sent_at IS NULL 인 row 를 골라 Kafka 로 발행하고
+--    성공 시 sent_at 을 채운다.
+-- =============================================================================
+
+CREATE TABLE outbox_events (
+    event_id      VARCHAR(36)  NOT NULL,
+    topic         VARCHAR(100) NOT NULL,
+    payload       MEDIUMTEXT   NOT NULL,
+    created_at    DATETIME(6)  NOT NULL,
+    sent_at       DATETIME(6),
+    PRIMARY KEY (event_id),
+    INDEX idx_unsent (sent_at, created_at)
+) ENGINE = InnoDB;

--- a/orderApi/src/test/java/com/zerobase/orderApi/saga/OutboxPollerTest.java
+++ b/orderApi/src/test/java/com/zerobase/orderApi/saga/OutboxPollerTest.java
@@ -1,0 +1,100 @@
+package com.zerobase.orderApi.saga;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.support.SendResult;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class OutboxPollerTest {
+
+    @Mock
+    private OutboxEventRepository outboxRepository;
+
+    @Mock
+    private KafkaTemplate<String, String> kafkaTemplate;
+
+    @InjectMocks
+    private OutboxPoller poller;
+
+    private OutboxEvent rowA;
+    private OutboxEvent rowB;
+
+    @BeforeEach
+    void setup() {
+        rowA = OutboxEvent.builder()
+                .eventId(UUID.randomUUID())
+                .topic("topic-a")
+                .payload("{\"a\":1}")
+                .createdAt(Instant.now().minusSeconds(2))
+                .build();
+        rowB = OutboxEvent.builder()
+                .eventId(UUID.randomUUID())
+                .topic("topic-b")
+                .payload("{\"b\":2}")
+                .createdAt(Instant.now().minusSeconds(1))
+                .build();
+    }
+
+    @Test
+    @DisplayName("정상 흐름: 각 미발행 row 를 send 하고 sent_at 마킹")
+    void publishes_and_marks_sent() {
+        given(outboxRepository.findTop100BySentAtIsNullOrderByCreatedAtAsc())
+                .willReturn(List.of(rowA, rowB));
+        given(kafkaTemplate.send(any(String.class), any(String.class), any(String.class)))
+                .willReturn(CompletableFuture.completedFuture(null));
+
+        poller.publishPending();
+
+        verify(kafkaTemplate).send(eq("topic-a"), eq(rowA.getEventId().toString()), eq("{\"a\":1}"));
+        verify(kafkaTemplate).send(eq("topic-b"), eq(rowB.getEventId().toString()), eq("{\"b\":2}"));
+        assertThat(rowA.getSentAt()).isNotNull();
+        assertThat(rowB.getSentAt()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("발행 실패 시 해당 row 및 이후 row 도 마킹하지 않고 break (순서 보장)")
+    void stops_on_failure_preserves_order() {
+        given(outboxRepository.findTop100BySentAtIsNullOrderByCreatedAtAsc())
+                .willReturn(List.of(rowA, rowB));
+        CompletableFuture<SendResult<String, String>> failed = new CompletableFuture<>();
+        failed.completeExceptionally(new RuntimeException("Kafka down"));
+        given(kafkaTemplate.send(eq("topic-a"), any(String.class), any(String.class)))
+                .willReturn(failed);
+
+        poller.publishPending();
+
+        verify(kafkaTemplate).send(eq("topic-a"), any(String.class), any(String.class));
+        verify(kafkaTemplate, never()).send(eq("topic-b"), any(String.class), any(String.class));
+        assertThat(rowA.getSentAt()).isNull();
+        assertThat(rowB.getSentAt()).isNull();
+    }
+
+    @Test
+    @DisplayName("미발행 row 가 없으면 Kafka 호출도 없다")
+    void no_op_when_empty() {
+        given(outboxRepository.findTop100BySentAtIsNullOrderByCreatedAtAsc())
+                .willReturn(List.of());
+
+        poller.publishPending();
+
+        verify(kafkaTemplate, never()).send(any(String.class), any(String.class), any(String.class));
+    }
+}

--- a/orderApi/src/test/java/com/zerobase/orderApi/saga/SagaEventPublisherTest.java
+++ b/orderApi/src/test/java/com/zerobase/orderApi/saga/SagaEventPublisherTest.java
@@ -1,0 +1,55 @@
+package com.zerobase.orderApi.saga;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.zerobase.orderApi.saga.event.SagaEvents;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class SagaEventPublisherTest {
+
+    @Mock
+    private OutboxEventRepository outboxRepository;
+
+    @Spy
+    private ObjectMapper objectMapper = new ObjectMapper();
+
+    @InjectMocks
+    private SagaEventPublisher publisher;
+
+    @Test
+    @DisplayName("publish: Kafka 가 아니라 outbox_events 에 INSERT 한다 (sent_at=NULL)")
+    void saves_to_outbox_not_kafka() {
+        UUID eventId = UUID.randomUUID();
+        SagaEvents.OrderCreated event = SagaEvents.OrderCreated.builder()
+                .eventId(eventId)
+                .orderId(1L)
+                .customerId(2L)
+                .username("u")
+                .totalPrice(10000)
+                .build();
+
+        publisher.publish(SagaTopics.ORDER_CREATED, event);
+
+        ArgumentCaptor<OutboxEvent> captor = ArgumentCaptor.forClass(OutboxEvent.class);
+        verify(outboxRepository).save(captor.capture());
+
+        OutboxEvent saved = captor.getValue();
+        assertThat(saved.getEventId()).isEqualTo(eventId);
+        assertThat(saved.getTopic()).isEqualTo(SagaTopics.ORDER_CREATED);
+        assertThat(saved.getPayload()).contains(eventId.toString());
+        assertThat(saved.getCreatedAt()).isNotNull();
+        assertThat(saved.getSentAt()).isNull();   // 폴러가 채울 때까지 null
+    }
+}

--- a/orderApi/src/test/resources/application.yml
+++ b/orderApi/src/test/resources/application.yml
@@ -28,6 +28,11 @@ spring:
     listener:
       auto-startup: false
 
+# Outbox poller 도 broker 가 없으니 테스트에서는 끈다 (ADR-004)
+outbox:
+  poller:
+    enabled: false
+
 # @SpringBootTest 가 UserClient (Feign) 빈을 생성할 때 placeholder 가 비어 있지 않도록 더미 값
 user-api:
   url: http://localhost:8080/user/customer

--- a/userApi/src/main/java/com/zerobase/userApi/UserApiApplication.java
+++ b/userApi/src/main/java/com/zerobase/userApi/UserApiApplication.java
@@ -4,10 +4,12 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.context.annotation.Bean;
+import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
 @EnableFeignClients
+@EnableScheduling
 @SpringBootApplication
 public class UserApiApplication {
 

--- a/userApi/src/main/java/com/zerobase/userApi/saga/OutboxEvent.java
+++ b/userApi/src/main/java/com/zerobase/userApi/saga/OutboxEvent.java
@@ -1,0 +1,42 @@
+package com.zerobase.userApi.saga;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.Instant;
+import java.util.UUID;
+
+/**
+ * Transactional Outbox (ADR-004) 의 발행 대기 row.
+ */
+@Entity
+@Table(name = "outbox_events", indexes = {
+        @Index(name = "idx_unsent", columnList = "sent_at, created_at")
+})
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class OutboxEvent {
+
+    @Id
+    @Column(name = "event_id", length = 36)
+    private UUID eventId;
+
+    @Column(nullable = false, length = 100)
+    private String topic;
+
+    @Lob
+    @Column(nullable = false)
+    private String payload;
+
+    @Column(name = "created_at", nullable = false)
+    private Instant createdAt;
+
+    @Column(name = "sent_at")
+    private Instant sentAt;
+
+    public void markSent(Instant when) {
+        this.sentAt = when;
+    }
+}

--- a/userApi/src/main/java/com/zerobase/userApi/saga/OutboxEventRepository.java
+++ b/userApi/src/main/java/com/zerobase/userApi/saga/OutboxEventRepository.java
@@ -1,0 +1,10 @@
+package com.zerobase.userApi.saga;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.UUID;
+
+public interface OutboxEventRepository extends JpaRepository<OutboxEvent, UUID> {
+    List<OutboxEvent> findTop100BySentAtIsNullOrderByCreatedAtAsc();
+}

--- a/userApi/src/main/java/com/zerobase/userApi/saga/OutboxPoller.java
+++ b/userApi/src/main/java/com/zerobase/userApi/saga/OutboxPoller.java
@@ -1,0 +1,46 @@
+package com.zerobase.userApi.saga;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * ADR-004: outbox_events 의 미발행 row 를 주기적으로 Kafka 로 발행.
+ */
+@Component
+@RequiredArgsConstructor
+@ConditionalOnProperty(name = "outbox.poller.enabled", havingValue = "true", matchIfMissing = true)
+@Slf4j
+public class OutboxPoller {
+
+    private static final Duration SEND_TIMEOUT = Duration.ofSeconds(3);
+
+    private final OutboxEventRepository outboxRepository;
+    private final KafkaTemplate<String, String> kafkaTemplate;
+
+    @Scheduled(fixedDelayString = "${outbox.poller.delay-ms:1000}")
+    @Transactional
+    public void publishPending() {
+        List<OutboxEvent> batch = outboxRepository.findTop100BySentAtIsNullOrderByCreatedAtAsc();
+        for (OutboxEvent row : batch) {
+            try {
+                kafkaTemplate.send(row.getTopic(), row.getEventId().toString(), row.getPayload())
+                        .get(SEND_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
+                row.markSent(Instant.now());
+            } catch (Exception e) {
+                log.warn("Failed to publish outbox event {} on topic {}: {}",
+                        row.getEventId(), row.getTopic(), e.getMessage());
+                break;
+            }
+        }
+    }
+}

--- a/userApi/src/main/java/com/zerobase/userApi/saga/SagaEventPublisher.java
+++ b/userApi/src/main/java/com/zerobase/userApi/saga/SagaEventPublisher.java
@@ -2,26 +2,40 @@ package com.zerobase.userApi.saga;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.zerobase.userApi.saga.event.SagaEvent;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
 
+import java.time.Instant;
+
+/**
+ * ADR-004: Kafka 로 직접 보내는 대신 outbox_events 테이블에 INSERT 만 한다.
+ */
 @Component
 @RequiredArgsConstructor
 @Slf4j
 public class SagaEventPublisher {
 
-    private final KafkaTemplate<String, String> kafkaTemplate;
+    private final OutboxEventRepository outboxRepository;
     private final ObjectMapper objectMapper;
 
-    public void publish(String topic, Object event) {
+    @Transactional(propagation = Propagation.MANDATORY)
+    public void publish(String topic, SagaEvent event) {
+        String payload;
         try {
-            String payload = objectMapper.writeValueAsString(event);
-            kafkaTemplate.send(topic, payload);
-            log.info("Published event to {}: {}", topic, payload);
+            payload = objectMapper.writeValueAsString(event);
         } catch (JsonProcessingException e) {
             throw new IllegalStateException("Failed to serialize event for topic " + topic, e);
         }
+        outboxRepository.save(OutboxEvent.builder()
+                .eventId(event.getEventId())
+                .topic(topic)
+                .payload(payload)
+                .createdAt(Instant.now())
+                .build());
+        log.debug("Outbox enqueued: topic={} eventId={}", topic, event.getEventId());
     }
 }

--- a/userApi/src/main/java/com/zerobase/userApi/saga/event/SagaEvent.java
+++ b/userApi/src/main/java/com/zerobase/userApi/saga/event/SagaEvent.java
@@ -1,0 +1,13 @@
+package com.zerobase.userApi.saga.event;
+
+import java.util.UUID;
+
+/**
+ * SAGA 이벤트의 공통 마커 인터페이스.
+ * 모든 이벤트는 발행자가 생성한 고유 UUID 를 노출해야 한다.
+ *
+ * - 발행 측(outbox row PK) 과 컨슈머 측(ProcessedEvent 멱등성 키) 에서 동일 UUID 를 공유한다.
+ */
+public interface SagaEvent {
+    UUID getEventId();
+}

--- a/userApi/src/main/java/com/zerobase/userApi/saga/event/SagaEvents.java
+++ b/userApi/src/main/java/com/zerobase/userApi/saga/event/SagaEvents.java
@@ -13,7 +13,7 @@ public class SagaEvents {
     @Builder
     @NoArgsConstructor
     @AllArgsConstructor
-    public static class OrderCreated {
+    public static class OrderCreated implements SagaEvent {
         private UUID eventId;
         private Long orderId;
         private Long customerId;
@@ -25,7 +25,7 @@ public class SagaEvents {
     @Builder
     @NoArgsConstructor
     @AllArgsConstructor
-    public static class PaymentDeducted {
+    public static class PaymentDeducted implements SagaEvent {
         private UUID eventId;
         private Long orderId;
     }
@@ -34,7 +34,7 @@ public class SagaEvents {
     @Builder
     @NoArgsConstructor
     @AllArgsConstructor
-    public static class PaymentFailed {
+    public static class PaymentFailed implements SagaEvent {
         private UUID eventId;
         private Long orderId;
         private String reason;
@@ -44,7 +44,7 @@ public class SagaEvents {
     @Builder
     @NoArgsConstructor
     @AllArgsConstructor
-    public static class StockReservationFailed {
+    public static class StockReservationFailed implements SagaEvent {
         private UUID eventId;
         private Long orderId;
         private Long customerId;
@@ -57,7 +57,7 @@ public class SagaEvents {
     @Builder
     @NoArgsConstructor
     @AllArgsConstructor
-    public static class PaymentReverted {
+    public static class PaymentReverted implements SagaEvent {
         private UUID eventId;
         private Long orderId;
     }

--- a/userApi/src/main/resources/db/migration/V4__add_outbox_events.sql
+++ b/userApi/src/main/resources/db/migration/V4__add_outbox_events.sql
@@ -1,0 +1,16 @@
+-- =============================================================================
+-- userApi V4: Transactional Outbox (ADR-004) 발행 대기 테이블
+--  - PaymentConsumer / RefundConsumer 의 SAGA 이벤트 발행 (PaymentDeducted /
+--    PaymentFailed / PaymentReverted) 을 컨슈머 트랜잭션과 같은 commit 단위로
+--    영속화하기 위해.
+-- =============================================================================
+
+CREATE TABLE outbox_events (
+    event_id      VARCHAR(36)  NOT NULL,
+    topic         VARCHAR(100) NOT NULL,
+    payload       MEDIUMTEXT   NOT NULL,
+    created_at    DATETIME(6)  NOT NULL,
+    sent_at       DATETIME(6),
+    PRIMARY KEY (event_id),
+    INDEX idx_unsent (sent_at, created_at)
+) ENGINE = InnoDB;

--- a/userApi/src/test/java/com/zerobase/userApi/saga/SagaEventPublisherTest.java
+++ b/userApi/src/test/java/com/zerobase/userApi/saga/SagaEventPublisherTest.java
@@ -1,0 +1,51 @@
+package com.zerobase.userApi.saga;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.zerobase.userApi.saga.event.SagaEvents;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class SagaEventPublisherTest {
+
+    @Mock
+    private OutboxEventRepository outboxRepository;
+
+    @Spy
+    private ObjectMapper objectMapper = new ObjectMapper();
+
+    @InjectMocks
+    private SagaEventPublisher publisher;
+
+    @Test
+    @DisplayName("publish: outbox_events 에 INSERT 만 한다 (sent_at=NULL)")
+    void saves_to_outbox_not_kafka() {
+        UUID eventId = UUID.randomUUID();
+        SagaEvents.PaymentDeducted event = SagaEvents.PaymentDeducted.builder()
+                .eventId(eventId)
+                .orderId(42L)
+                .build();
+
+        publisher.publish(SagaTopics.PAYMENT_DEDUCTED, event);
+
+        ArgumentCaptor<OutboxEvent> captor = ArgumentCaptor.forClass(OutboxEvent.class);
+        verify(outboxRepository).save(captor.capture());
+
+        OutboxEvent saved = captor.getValue();
+        assertThat(saved.getEventId()).isEqualTo(eventId);
+        assertThat(saved.getTopic()).isEqualTo(SagaTopics.PAYMENT_DEDUCTED);
+        assertThat(saved.getPayload()).contains(eventId.toString());
+        assertThat(saved.getSentAt()).isNull();
+    }
+}

--- a/userApi/src/test/resources/application.yml
+++ b/userApi/src/test/resources/application.yml
@@ -27,3 +27,8 @@ spring:
       group-id: test
     listener:
       auto-startup: false
+
+# Outbox poller 도 broker 가 없으니 테스트에서는 끈다 (ADR-004)
+outbox:
+  poller:
+    enabled: false


### PR DESCRIPTION
## 관련 이슈
Closes #35

## 변경 유형
- [x] ✨ Feature
- [x] 🛠 Refactor / Chore
- [x] 🗄 DB 마이그레이션 (Flyway V_*.sql 추가)
- [x] 📝 Docs

## 요약

ADR-004 의 결정대로 SAGA 이벤트 발행을 **Transactional Outbox** 로 전환.

- `SagaEventPublisher.publish()` 가 더 이상 `kafkaTemplate.send()` 를 직접 호출하지 않고, 같은 DB 의 \`outbox_events\` 테이블에 INSERT 만 한다.
- 비즈니스 row (Order / ProcessedEvent / CustomerBalanceHistory 등) 와 outbox row 가 **한 트랜잭션** 으로 묶여 같이 commit / 같이 rollback.
- 별도 \`OutboxPoller\` (@Scheduled) 가 주기적으로 미발행 row 를 읽어 Kafka 로 발행하고 \`sent_at\` 마킹.
- ADR-003 의 \`ProcessedEvent\` (컨슈머 측 멱등성) 와 짝을 이뤄 **effectively-exactly-once**.

## 영향 받는 모듈
- [x] userApi
- [x] orderApi
- [ ] gateway
- [ ] infra (docker-compose, CI, etc.)

## 동작 확인

- \`./gradlew test\` 양 모듈 통과 (SagaEventPublisherTest, OutboxPollerTest, 기존 SAGA 테스트 모두 정상)
- 테스트 환경에서는 \`outbox.poller.enabled=false\` 로 폴러를 끄고 컨텍스트만 부팅 — broker 없이 통과
- docker-compose 환경에서 end-to-end 동작은 별도 수동 검증 필요

## 체크리스트
- [x] 단위 / 통합 테스트 통과 (\`./gradlew test\`)
- [x] DB 스키마 변경이 있다면 Flyway 마이그레이션 (\`V_*.sql\`) 추가 — orderApi V5, userApi V4
- [x] 두 모듈에 공유되는 DTO/Authority 등 변경 시 양쪽 모두 반영 — \`SagaEvent\`, \`OutboxEvent\`, \`OutboxEventRepository\`, \`OutboxPoller\` 모두 양 모듈에 동일 구조로 추가
- [x] 운영 yaml(\`application.yml\`)에 추가된 설정이 있다면 \`application-test.yml\` 및 \`docker-compose.test.yml\`에도 반영 — 테스트 환경에 \`outbox.poller.enabled=false\` 추가
- [x] 외부 API 추가/변경 시 Swagger 문서 갱신 — 외부 API 변화 없음

## 주요 변경

### 새 도메인 / 인프라
- \`SagaEvent\` 마커 인터페이스 (\`UUID getEventId()\`). 기존 \`SagaEvents.*\` 내부 클래스 5종이 implement.
- \`OutboxEvent\` 엔티티 + \`OutboxEventRepository\` (양 모듈)
- Flyway: \`orderApi V5\`, \`userApi V4\` — 동일 스키마(\`outbox_events\`)
- \`@EnableScheduling\` (OrderApiApplication, UserApiApplication)

### 발행자 / 폴러
- \`SagaEventPublisher.publish(String, SagaEvent)\`:
  - \`@Transactional(propagation = MANDATORY)\` — 호출자 트랜잭션 강제 합류
  - 내부 동작: \`outboxRepository.save(...)\`
- \`OutboxPoller\` (@Scheduled, fixedDelay=1s):
  - 미발행 row top 100 시간순 SELECT → 각 row \`kafkaTemplate.send\` 동기 대기 → \`sent_at\` 마킹
  - 발행 실패 시 break (순서 보장)
  - \`outbox.poller.enabled\` 프로퍼티로 활성/비활성 (기본 true)

### 호출자 (변경 없음)
- \`OrderService.order()\`, \`PaymentConsumer.process()\`, \`StockConsumer.publishStockReservationFailed()\`, \`RefundConsumer.process()\` — 모두 기존 그대로 \`publisher.publish(...)\` 호출. 이벤트 객체가 \`SagaEvent\` 를 구현하므로 시그니처 변경에 자연스럽게 적응.

### 테스트
- \`SagaEventPublisherTest\` (양 모듈): outbox 저장 + sent_at=NULL 검증
- \`OutboxPollerTest\` (orderApi): 정상 / 실패 시 break / 빈 batch no-op

## 알려진 제약 / 후속 항목
- **폴러의 단일성 보장** — 멀티 인스턴스 배포 시 중복 발행 가능 (ProcessedEvent 가 흡수하지만 Kafka 부하 증가). \`SELECT ... FOR UPDATE SKIP LOCKED\` 또는 ShedLock 같은 분산락 적용은 후속 작업.
- **outbox_events 정리** — sent_at 채워진 row 의 주기적 삭제(예: 7일 retention) 는 별도 cron / 스케줄러로 분리.
- **CDC 대안** — 더 낮은 latency 가 필요하면 Debezium / Kafka Connect 로 outbox 의 binlog 를 실시간 흘리는 방식 검토.
- **EmbeddedKafka end-to-end 테스트** — 본 PR 범위 밖.