### PR TITLE
feat: ADR-005 Eureka + Gateway LoadBalancer 도입

### DIFF
--- a/ADR/005-eureka-gateway-load-balancing.md
+++ b/ADR/005-eureka-gateway-load-balancing.md
@@ -1,0 +1,282 @@
+# ADR 005: orderApi 다중 인스턴스 부하 분산을 위한 Eureka + Gateway LoadBalancer 도입
+
+- 상태: 제안 (Proposed)
+- 작성일: 2026-05-26
+- 관련 코드: [gateway/application.yml](../gateway/src/main/resources/application.yml), [CustomerCartController.java](../orderApi/src/main/java/com/zerobase/orderApi/controller/CustomerCartController.java)
+
+## 컨텍스트
+
+현재 gateway 는 백엔드 주소를 application.yml 에 하드코딩한다 ([application.yml:9-15](../gateway/src/main/resources/application.yml#L9-L15)).
+
+```yaml
+spring:
+  cloud:
+    gateway:
+      routes:
+      - id: order-api
+        uri: http://ip-172-31-14-142.ap-northeast-2.compute.internal:8080
+        predicates:
+        - Path=/order/**
+```
+
+orderApi · userApi 는 각 1 인스턴스로 운영된다. ADR-003 (Choreography SAGA) 과 ADR-004 (Transactional Outbox) 적용 후 orderApi 는 **stateless** 가 되어 (Cart 는 Redis, 이벤트는 outbox table) 인스턴스 추가만으로 수평 확장이 안전한 상태다. 그러나 gateway 가 단일 백엔드 주소를 갖고 있어 다중화의 이점을 활용하지 못한다.
+
+본 ADR 은 단일 인스턴스 + 하드코딩 라우팅 방식의 운영 한계를 정리하고, Eureka + Spring Cloud Gateway LoadBalancer 도입을 제안한다.
+
+## 현재 방식의 문제 시나리오
+
+### 시나리오 1. 트래픽 급증 시 단일 인스턴스 자원 천장 도달
+
+특정 시간대 (점심·세일 오픈 등) 에 동시 주문이 몰리면 단일 orderApi 의 HikariCP 풀 · CPU · GC 가 한계에 도달한다.
+
+```mermaid
+sequenceDiagram
+    autonumber
+    actor U1 as Customer 1
+    actor U2 as Customer 2
+    actor Un as Customer N
+    participant GW as gateway
+    participant Ord as orderApi (단일)
+    participant ODB as MySQL
+
+    par 동시 주문 폭증
+        U1->>GW: POST /order/customer/cart/order
+        GW->>Ord: route
+        U2->>GW: POST /order/customer/cart/order
+        GW->>Ord: route
+        Un->>GW: POST /order/customer/cart/order
+        GW->>Ord: route
+    end
+
+    Note over Ord: HikariCP 풀 = 10<br/>진행 요청 = 200<br/>190 요청이 connection 대기
+    Ord->>ODB: BEGIN
+    ODB-->>Ord: 풀 고갈 → 대기
+    Note over Ord: connection-timeout 초과
+    Ord--xGW: 500 / 504
+    GW-->>U1: 500 / 504
+
+    Note over U1: 클라이언트 timeout 인지 후 재시도
+    U1->>GW: POST /order (재시도, 다른 Idempotency-Key)
+    Note over GW,Ord: 같은 상황 → cascade timeout
+    Note over U1,Ord: retry storm 으로 부하 가중
+```
+
+문제점: 한 인스턴스의 자원이 천장에 닿으면 p99 latency 가 폭증해 client timeout 이 발생. 클라이언트가 동일한 Idempotency-Key 를 붙이지 않은 채 재시도하면 중복 주문 위험까지. 단일 인스턴스인 이상 수평 확장으로 흡수할 경로가 없다.
+
+### 시나리오 2. 인스턴스 장애로 전체 서비스 중단
+
+OOM kill, JVM crash, OS reboot, deploy 중 SIGTERM 등 어느 이유로든 단일 orderApi 가 죽으면 gateway 의 백엔드가 사라진다.
+
+```mermaid
+sequenceDiagram
+    autonumber
+    actor U as Customer
+    participant GW as gateway
+    participant Ord as orderApi (단일)
+
+    U->>GW: POST /order/customer/cart/order
+    GW->>Ord: route
+    Note over Ord: OOMKilled / JVM crash
+    Ord--xGW: Connection refused
+    GW-->>U: 502 Bad Gateway
+
+    Note over Ord: 컨테이너 재기동 (30~60s)<br/>+ Spring 부트 (10~30s)<br/>+ Flyway · JPA 초기화
+
+    loop 복구 완료 전까지 모든 요청
+        U->>GW: POST /order
+        GW->>Ord: route
+        Ord--xGW: Connection refused
+        GW-->>U: 502
+    end
+
+    Note over Ord: ready
+    U->>GW: POST /order
+    GW->>Ord: route
+    Ord-->>GW: 200 OK
+    GW-->>U: 200 OK
+```
+
+문제점: gateway 가 단일 백엔드 주소를 갖고 있어 fallback 이 없다. 인스턴스 부팅 동안 (보통 1~3 분) 주문 0 건. **단일 점 (single point of failure)** 이 전체 매출에 직접 영향. 운영자가 즉시 알아채야 함.
+
+### 시나리오 3. 배포 시 다운타임
+
+신버전 배포는 단일 인스턴스를 종료하고 새 인스턴스를 띄우는 방식이라 무중단 배포 불가. 인스턴스가 1 개뿐이므로 종료 ~ 신버전 ready 사이의 신규 요청을 받을 곳이 없다.
+
+```mermaid
+sequenceDiagram
+    autonumber
+    actor U as Customer
+    participant GW as gateway
+    participant Ord as orderApi (단일)
+
+    Note over Ord: 배포 트리거 → SIGTERM 수신
+    Note over Ord: graceful shutdown 으로 in-flight 요청 drain 후 종료<br/>(graceful shutdown 자체는 단일 인스턴스도 가능)
+
+    loop 구버전 종료 ~ 신버전 ready (30~90s)
+        U->>GW: POST /order
+        GW->>Ord: route
+        Ord--xGW: Connection refused
+        GW-->>U: 502 Bad Gateway
+    end
+
+    Note over Ord: 신버전 ready
+    U->>GW: POST /order
+    GW->>Ord: route
+    Ord-->>GW: 200 OK
+    GW-->>U: 200 OK
+```
+
+문제점: 인스턴스가 1 개라 배포 중 신규 요청을 받을 인스턴스가 없다. graceful shutdown 으로 진행 중 요청은 안전하게 마무리되지만, **새로 들어오는 사용자는 30~90 초간 모두 502**. 배포 빈도가 높을수록 누적 다운타임이 매출에 직접 영향.
+
+---
+
+## 종합 (현재 한계)
+
+| 시나리오 | 원인 | 결과 |
+|---|---|---|
+| 1. 트래픽 폭증 | 단일 인스턴스 자원 한계 | p99 폭증, retry storm, 중복 주문 위험 |
+| 2. 인스턴스 장애 | gateway 가 단일 백엔드만 앎 | 부팅 완료까지 전체 서비스 중단 |
+| 3. 배포 다운타임 | 인스턴스 1 개, fallback 없음 | 배포 중 신규 요청 모두 502 |
+
+공통 원인: **gateway 가 백엔드 인스턴스의 동적 토폴로지를 인지하지 못한다**. 인스턴스 추가 / 제거 / 장애가 일어나도 gateway 는 모르고, 사람이 yml 을 고쳐야 안다.
+
+## 결정 (제안): Eureka Server + Spring Cloud Gateway LoadBalancer
+
+- 각 orderApi 인스턴스는 기동 시 **Eureka Server** 에 자신의 (service-id, host, port) 를 등록하고 30 초마다 heartbeat 전송. 종료 시 deregister.
+- gateway 는 정적 uri 대신 `lb://order-api` 형태의 logical service id 로 라우팅 정의. 내부적으로 Eureka registry 를 fetch 해 인스턴스 목록을 캐시하고 round-robin (또는 weighted) LB 로 분배.
+- 인스턴스 추가 / 제거는 등록 / 해제만으로 즉시 반영. gateway 재빌드 / 재배포 불필요.
+
+```yaml
+spring:
+  cloud:
+    gateway:
+      routes:
+      - id: order-api
+        uri: lb://order-api   # ← 하드코딩 주소 → Eureka service-id
+        predicates:
+        - Path=/order/**
+```
+
+## 도입 후 시나리오
+
+### 시나리오 1'. 트래픽 분산으로 자원 천장 우회
+
+```mermaid
+sequenceDiagram
+    autonumber
+    actor U1 as Customer 1
+    actor U2 as Customer 2
+    actor Un as Customer N
+    participant GW as gateway
+    participant Eu as Eureka Server
+    participant O1 as orderApi #1
+    participant O2 as orderApi #2
+    participant O3 as orderApi #3
+
+    par 인스턴스 셋 모두 등록
+        O1->>Eu: register + heartbeat
+        O2->>Eu: register + heartbeat
+        O3->>Eu: register + heartbeat
+    end
+
+    GW->>Eu: fetch registry (30s 주기)
+    Eu-->>GW: [O1, O2, O3]
+
+    par 트래픽 분산
+        U1->>GW: POST /order
+        GW->>O1: route (round-robin)
+        U2->>GW: POST /order
+        GW->>O2: route
+        Un->>GW: POST /order
+        GW->>O3: route
+    end
+
+    Note over O1,O3: 각 인스턴스의 자원 부하 = 1/N<br/>HikariCP · CPU · GC 모두 여유<br/>p99 안정
+```
+
+문제 해결: 인스턴스를 N 개로 늘리면 동일 트래픽이 1/N 로 분산. HikariCP · CPU 천장이 멀어져 p99 안정. retry storm 없음.
+
+### 시나리오 2'. 인스턴스 장애 자동 우회
+
+```mermaid
+sequenceDiagram
+    autonumber
+    actor U as Customer
+    participant GW as gateway
+    participant Eu as Eureka Server
+    participant O1 as orderApi #1 (정상)
+    participant O2 as orderApi #2 (장애)
+    participant O3 as orderApi #3 (정상)
+
+    Note over O2: OOMKilled
+    O2--xEu: heartbeat 중단
+    Note over Eu: lease expiration (~90s 후)<br/>registry 에서 O2 제거
+    GW->>Eu: fetch registry
+    Eu-->>GW: [O1, O3]
+
+    U->>GW: POST /order
+    GW->>O1: route
+    O1-->>GW: 200
+    GW-->>U: 200
+
+    U->>GW: POST /order
+    GW->>O3: route
+    O3-->>GW: 200
+    GW-->>U: 200
+
+    Note over U,Eu: 사용자에게 서비스 중단 없음<br/>(O2 만큼의 capacity 일시 감소)
+```
+
+문제 해결: gateway 가 등록된 모든 인스턴스를 알고 있으므로 일부가 죽어도 나머지로 라우팅. lease expiration 까지 (~90 초) 일부 요청이 죽은 인스턴스로 갈 수 있으나, Spring Cloud LB 의 retry 정책으로 다음 인스턴스로 재시도 가능.
+
+### 시나리오 3'. 무중단 rolling 배포
+
+```mermaid
+sequenceDiagram
+    autonumber
+    actor U as Customer
+    participant GW as gateway
+    participant Eu as Eureka Server
+    participant O1 as orderApi #1
+    participant O2 as orderApi #2
+    participant O3 as orderApi #3
+
+    Note over O1: 신버전 배포 차례
+    O1->>Eu: deregister
+    Note over Eu: O1 제거
+    GW->>Eu: fetch
+    Eu-->>GW: [O2, O3]
+
+    Note over O1: graceful shutdown → 종료
+
+    U->>GW: POST /order
+    GW->>O2: route (O1 은 풀에서 빠짐)
+    O2-->>U: 200
+
+    Note over O1: 신버전 기동 + ready
+    O1->>Eu: register (신버전)
+    GW->>Eu: fetch
+    Eu-->>GW: [O1(신), O2(구), O3(구)]
+
+    Note over O2: 다음 배포 차례<br/>(rolling 반복)
+```
+
+문제 해결: 인스턴스를 1 개씩 deregister → 종료 → 신버전 기동 → register 순으로 교체. 항상 N-1 개가 트래픽을 받으므로 **신규 요청 다운타임 0**. 각 인스턴스의 graceful shutdown 은 이전과 동일하게 적용되어 in-flight 요청도 정상 마무리.
+
+---
+
+## 도입 후 종합
+
+| 시나리오 | 단일 인스턴스 + 하드코딩 | Eureka + LB |
+|---|---|---|
+| 1. 트래픽 폭증 | 자원 천장, retry storm | 1/N 분산, 자원 여유 |
+| 2. 인스턴스 장애 | 전체 서비스 중단 | 자동 우회, 무중단 |
+| 3. 배포 다운타임 | 배포 중 신규 요청 모두 502 | rolling 무중단 |
+
+요약: **백엔드 토폴로지의 동적 변화를 gateway 가 인지** 하게 되어, 인스턴스의 추가 / 제거 / 장애가 사용자 경험과 운영 작업에서 분리된다.
+
+## 남는 책임
+
+- **다인스턴스 시 OutboxPoller 중복 발행** — 모든 orderApi 인스턴스에서 `@Scheduled` polling 이 동시 실행되어 같은 row 가 N 회 발행될 수 있다. ProcessedEvent 가 컨슈머 단에서 흡수하지만 Kafka 부하 증가. 분산 락 (Redis Redlock, ShedLock) 또는 `SELECT ... FOR UPDATE SKIP LOCKED` 도입은 별도 ADR.
+- **Eureka Server 가용성** — Eureka Server 가 단일이면 등록 · 발견이 막힌다. 운영 시 Eureka 클러스터 구성 또는 client-side cache 신뢰 정책 (`registry-fetch-interval-seconds`, `eureka.instance.lease-renewal-interval-in-seconds` 튜닝) 필요.
+- **lease expiration 동안의 stale routing** — 인스턴스가 죽은 직후 Eureka 가 만료시키기까지 (~90 초) gateway 가 죽은 인스턴스로 라우팅할 수 있음. Spring Cloud LB 의 retry · circuit breaker · health check 설정으로 사용자 영향 최소화 필요.

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -74,6 +74,25 @@ services:
       start_period: 30s
     networks: [commerce-test]
 
+  # ADR-005: 서비스 디스커버리 레지스트리
+  eureka:
+    build:
+      context: ./eurekaServer
+      dockerfile: Dockerfile
+    container_name: commerce-eureka-test
+    ports:
+      - "8761:8761"
+    healthcheck:
+      # Eureka Server 의 status 페이지로 ready 확인
+      test: ["CMD-SHELL", "curl -fsS http://localhost:8761/ > /dev/null || exit 1"]
+      interval: 5s
+      timeout: 5s
+      retries: 30
+      start_period: 20s
+    networks: [commerce-test]
+
+  # ADR-005: userApi 는 단일 인스턴스 유지 (orderApi LB 효과만 측정하기 위한 고정 변수).
+  # 인스턴스당 자원 4 CPU / 2GB 로 제한 → 단일 인스턴스 천장 도달 시점을 명확히.
   userapi:
     build:
       context: ./userApi
@@ -89,6 +108,8 @@ services:
       MAILGUN_APIKEY: ${MAILGUN_APIKEY:-test-key}
       MAILGUN_DOMAIN: ${MAILGUN_DOMAIN:-test.local}
       KAFKA_BOOTSTRAP_SERVERS: kafka:9092
+      # ADR-005: Eureka 클라이언트 등록 대상
+      EUREKA_SERVER_URL: http://eureka:8761/eureka/
     ports:
       - "8081:8080"
     depends_on:
@@ -96,13 +117,23 @@ services:
         condition: service_healthy
       kafka:
         condition: service_healthy
+      eureka:
+        condition: service_healthy
+    deploy:
+      resources:
+        limits:
+          cpus: '4'
+          memory: 2G
     networks: [commerce-test]
 
+  # ADR-005: orderApi 는 다중 인스턴스 측정 대상.
+  #   `docker compose -f docker-compose.test.yml up --scale orderapi=4` 로 N 인스턴스 기동.
+  # 인스턴스당 자원 4 CPU / 2GB 로 제한 → 분산 효과를 정량적으로 비교.
+  # container_name 과 호스트 port 바인딩은 제거 (--scale 시 충돌 방지). 외부 접근은 gateway 경유.
   orderapi:
     build:
       context: ./orderApi
       dockerfile: Dockerfile
-    container_name: commerce-orderapi-test
     environment:
       SPRING_PROFILES_ACTIVE: test
       MYSQL_HOST: mysql-order
@@ -115,8 +146,8 @@ services:
       # orderApi -> userApi 결제 호출. gateway 경유 (gateway가 /user/** 를 userapi:8080 으로 RewritePath)
       USER_API_URL: http://gateway/user/customer
       KAFKA_BOOTSTRAP_SERVERS: kafka:9092
-    ports:
-      - "8082:8080"
+      # ADR-005: Eureka 클라이언트 등록 대상
+      EUREKA_SERVER_URL: http://eureka:8761/eureka/
     depends_on:
       mysql-order:
         condition: service_healthy
@@ -124,8 +155,17 @@ services:
         condition: service_healthy
       kafka:
         condition: service_healthy
+      eureka:
+        condition: service_healthy
+    deploy:
+      resources:
+        limits:
+          cpus: '4'
+          memory: 2G
     networks: [commerce-test]
 
+  # ADR-005: gateway 는 단일 인스턴스 + lb:// 라우팅.
+  # 인스턴스당 자원 4 CPU / 2GB 로 제한 (백엔드 분산 효과와 gateway 자체 한계를 분리).
   gateway:
     build:
       context: ./gateway
@@ -133,13 +173,23 @@ services:
     container_name: commerce-gateway-test
     environment:
       SPRING_PROFILES_ACTIVE: test
-      USER_API_URI: http://userapi:8080
-      ORDER_API_URI: http://orderapi:8080
+      # ADR-005: 라우트는 lb://order-api, lb://user-api 로 정의됨.
+      # 백엔드 인스턴스 주소는 Eureka 에서 동적 발견.
+      EUREKA_SERVER_URL: http://eureka:8761/eureka/
     ports:
       - "8080:80"
     depends_on:
-      - userapi
-      - orderapi
+      eureka:
+        condition: service_healthy
+      userapi:
+        condition: service_started
+      orderapi:
+        condition: service_started
+    deploy:
+      resources:
+        limits:
+          cpus: '4'
+          memory: 2G
     networks: [commerce-test]
 
 networks:

--- a/eurekaServer/Dockerfile
+++ b/eurekaServer/Dockerfile
@@ -1,0 +1,5 @@
+FROM openjdk:17
+RUN mkdir -p deploy
+WORKDIR /deploy
+COPY ./build/libs/eurekaServer-0.1.jar eureka-server.jar
+ENTRYPOINT ["java", "-jar", "/deploy/eureka-server.jar"]

--- a/eurekaServer/build.gradle
+++ b/eurekaServer/build.gradle
@@ -1,0 +1,24 @@
+plugins {
+    id 'java'
+    id 'org.springframework.boot' version '3.3.0'
+    id 'io.spring.dependency-management' version '1.1.4'
+}
+
+version '0.1'
+
+apply from: rootProject.file('shared.gradle')
+
+ext {
+    set('springCloudVersion', '2023.0.2')
+}
+
+dependencyManagement {
+    imports {
+        mavenBom "org.springframework.cloud:spring-cloud-dependencies:${springCloudVersion}"
+    }
+}
+
+dependencies {
+    // ADR-005: Eureka Server (서비스 디스커버리)
+    implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-server'
+}

--- a/eurekaServer/src/main/java/com/zerobase/eurekaserver/EurekaServerApplication.java
+++ b/eurekaServer/src/main/java/com/zerobase/eurekaserver/EurekaServerApplication.java
@@ -1,0 +1,19 @@
+package com.zerobase.eurekaserver;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.netflix.eureka.server.EnableEurekaServer;
+
+/**
+ * ADR-005: 서비스 디스커버리 레지스트리.
+ *  - gateway / orderApi / userApi 인스턴스가 자기 주소를 등록하고
+ *    gateway 는 인스턴스 목록을 fetch 해 lb:// 라우팅에 사용한다.
+ */
+@SpringBootApplication
+@EnableEurekaServer
+public class EurekaServerApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(EurekaServerApplication.class, args);
+    }
+}

--- a/eurekaServer/src/main/resources/application-test.yml
+++ b/eurekaServer/src/main/resources/application-test.yml
@@ -1,0 +1,2 @@
+server:
+  port: 8761

--- a/eurekaServer/src/main/resources/application.yml
+++ b/eurekaServer/src/main/resources/application.yml
@@ -1,0 +1,20 @@
+server:
+  port: 8761
+
+spring:
+  application:
+    name: eureka-server
+
+eureka:
+  client:
+    # Eureka Server 자기 자신은 다른 Eureka 에 등록할 필요 없음
+    register-with-eureka: false
+    fetch-registry: false
+    service-url:
+      defaultZone: http://localhost:8761/eureka/
+  server:
+    # ADR-005 측정 환경에서는 self-preservation 비활성:
+    # 인스턴스 추가/제거가 빠르게 registry 에 반영되도록 한다.
+    # 운영 환경에서는 true 권장.
+    enable-self-preservation: false
+    eviction-interval-timer-in-ms: 5000

--- a/gateway/build.gradle
+++ b/gateway/build.gradle
@@ -20,4 +20,8 @@ dependencyManagement {
 
 dependencies {
     implementation 'org.springframework.cloud:spring-cloud-starter-gateway'
+
+    // ADR-005: Eureka 클라이언트로 등록 + lb:// 라우팅용 LoadBalancer
+    implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
+    implementation 'org.springframework.cloud:spring-cloud-starter-loadbalancer'
 }

--- a/gateway/src/main/resources/application-test.yml
+++ b/gateway/src/main/resources/application-test.yml
@@ -2,23 +2,34 @@ server:
   port: 80
 
 spring:
+  application:
+    name: gateway
   cloud:
     gateway:
       routes:
+        # ADR-005: 하드코딩 주소 → Eureka service-id 기반 lb:// 라우팅
         - id: user-api
-          uri: ${USER_API_URI}
+          uri: lb://user-api
           predicates:
             - Path=/user/**
           filters:
             - RewritePath=/user/(?<path>.*), /$\{path}
         - id: order-api
-          uri: ${ORDER_API_URI}
+          uri: lb://order-api
           predicates:
             - Path=/order/**
           filters:
             - RewritePath=/order/(?<path>.*), /$\{path}
 
+eureka:
+  client:
+    service-url:
+      defaultZone: ${EUREKA_SERVER_URL:http://localhost:8761/eureka/}
+  instance:
+    prefer-ip-address: true
+
 logging:
   level:
     org.springframework.cloud.gateway: DEBUG
     reactor.netty.http.client: DEBUG
+    com.netflix.discovery: INFO

--- a/gateway/src/main/resources/application.yml
+++ b/gateway/src/main/resources/application.yml
@@ -2,18 +2,28 @@ server:
   port: 80
 
 spring:
+  application:
+    name: gateway
   cloud:
     gateway:
       routes:
+      # ADR-005: 하드코딩 주소 → Eureka service-id 기반 lb:// 라우팅
       - id: user-api
-        uri: http://ip-172-31-14-162.ap-northeast-2.compute.internal:8080
+        uri: lb://user-api
         predicates:
         - Path=/user/**
         filters:
         - RewritePath=/user/(?<path>.*), /$\{path}
       - id: order-api
-        uri: http://ip-172-31-14-142.ap-northeast-2.compute.internal:8080
+        uri: lb://order-api
         predicates:
         - Path=/order/**
         filters:
         - RewritePath=/order/(?<path>.*), /$\{path}
+
+eureka:
+  client:
+    service-url:
+      defaultZone: ${EUREKA_SERVER_URL:http://localhost:8761/eureka/}
+  instance:
+    prefer-ip-address: true

--- a/orderApi/build.gradle
+++ b/orderApi/build.gradle
@@ -22,6 +22,9 @@ dependencies {
     //cloud
     implementation 'org.springframework.cloud:spring-cloud-starter-openfeign:4.1.2'
 
+    // ADR-005: Eureka 클라이언트 등록
+    implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
+
     //Jpa
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.data:spring-data-envers'

--- a/orderApi/src/main/resources/application-test.yml
+++ b/orderApi/src/main/resources/application-test.yml
@@ -2,6 +2,8 @@ server:
   port: 8080
 
 spring:
+  application:
+    name: order-api
   datasource:
     url: jdbc:mysql://${MYSQL_HOST}:${MYSQL_PORT}/${MYSQL_DATABASE}?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=UTC
     username: ${MYSQL_USER}
@@ -36,7 +38,18 @@ spring:
 user-api:
   url: ${USER_API_URL}
 
+# ADR-005: Eureka 클라이언트 등록
+eureka:
+  client:
+    service-url:
+      defaultZone: ${EUREKA_SERVER_URL:http://localhost:8761/eureka/}
+  instance:
+    prefer-ip-address: true
+    # 다인스턴스 환경에서 인스턴스별 고유 식별자
+    instance-id: ${spring.application.name}:${spring.cloud.client.hostname:${HOSTNAME:localhost}}:${server.port}
+
 logging:
   level:
     org.hibernate.SQL: DEBUG
     com.zerobase.orderApi: DEBUG
+    com.netflix.discovery: INFO

--- a/orderApi/src/main/resources/application.yml
+++ b/orderApi/src/main/resources/application.yml
@@ -2,6 +2,8 @@ server:
   port: 8080
 
 spring:
+  application:
+    name: order-api
   datasource:
     url: jdbc:mysql://commerce-mysql.c90qy2aumeaj.ap-northeast-2.rds.amazonaws.com:3306/orders
     username: commerce
@@ -40,3 +42,13 @@ spring:
 
 user-api:
   url: http://ec2-43-202-0-143.ap-northeast-2.compute.amazonaws.com/user/customer
+
+# ADR-005: Eureka 클라이언트 등록
+eureka:
+  client:
+    service-url:
+      defaultZone: ${EUREKA_SERVER_URL:http://localhost:8761/eureka/}
+  instance:
+    prefer-ip-address: true
+    # 다인스턴스에서 인스턴스별 고유 식별자 (host 가 같아도 구분되도록)
+    instance-id: ${spring.application.name}:${spring.cloud.client.hostname:${HOSTNAME:localhost}}:${server.port}

--- a/orderApi/src/test/resources/application.yml
+++ b/orderApi/src/test/resources/application.yml
@@ -36,3 +36,10 @@ outbox:
 # @SpringBootTest 가 UserClient (Feign) 빈을 생성할 때 placeholder 가 비어 있지 않도록 더미 값
 user-api:
   url: http://localhost:8080/user/customer
+
+# ADR-005: Eureka Server 없이도 테스트 컨텍스트가 부팅되도록 클라이언트 비활성화
+eureka:
+  client:
+    enabled: false
+    register-with-eureka: false
+    fetch-registry: false

--- a/settings.gradle
+++ b/settings.gradle
@@ -3,4 +3,5 @@ include 'userApi'
 include 'Auth'
 include 'orderApi'
 include 'gateway'
+include 'eurekaServer'
 

--- a/userApi/build.gradle
+++ b/userApi/build.gradle
@@ -22,6 +22,9 @@ dependencies {
     //cloud
     implementation 'org.springframework.cloud:spring-cloud-starter-openfeign:4.1.2'
 
+    // ADR-005: Eureka 클라이언트 등록
+    implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
+
     //Jpa
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.data:spring-data-envers'

--- a/userApi/src/main/resources/application-test.yml
+++ b/userApi/src/main/resources/application-test.yml
@@ -2,6 +2,8 @@ server:
   port: 8080
 
 spring:
+  application:
+    name: user-api
   datasource:
     url: jdbc:mysql://${MYSQL_HOST}:${MYSQL_PORT}/${MYSQL_DATABASE}?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=UTC
     username: ${MYSQL_USER}
@@ -29,7 +31,18 @@ mailgun:
   apiKey: ${MAILGUN_APIKEY}
   domain: ${MAILGUN_DOMAIN}
 
+# ADR-005: Eureka 클라이언트 등록
+eureka:
+  client:
+    service-url:
+      defaultZone: ${EUREKA_SERVER_URL:http://localhost:8761/eureka/}
+  instance:
+    prefer-ip-address: true
+    # 다인스턴스 환경에서 인스턴스별 고유 식별자
+    instance-id: ${spring.application.name}:${spring.cloud.client.hostname:${HOSTNAME:localhost}}:${server.port}
+
 logging:
   level:
     org.hibernate.SQL: DEBUG
     com.zerobase.userApi: DEBUG
+    com.netflix.discovery: INFO

--- a/userApi/src/main/resources/application.yml
+++ b/userApi/src/main/resources/application.yml
@@ -2,6 +2,8 @@ server:
   port: 8080
 
 spring:
+  application:
+    name: user-api
   datasource:
     url: jdbc:mysql://commerce-mysql.c90qy2aumeaj.ap-northeast-2.rds.amazonaws.com:3306/user
     username: commerce
@@ -32,3 +34,12 @@ spring:
     producer:
       key-serializer: org.apache.kafka.common.serialization.StringSerializer
       value-serializer: org.apache.kafka.common.serialization.StringSerializer
+
+# ADR-005: Eureka 클라이언트 등록
+eureka:
+  client:
+    service-url:
+      defaultZone: ${EUREKA_SERVER_URL:http://localhost:8761/eureka/}
+  instance:
+    prefer-ip-address: true
+    instance-id: ${spring.application.name}:${spring.cloud.client.hostname:${HOSTNAME:localhost}}:${server.port}

--- a/userApi/src/test/resources/application.yml
+++ b/userApi/src/test/resources/application.yml
@@ -32,3 +32,10 @@ spring:
 outbox:
   poller:
     enabled: false
+
+# ADR-005: Eureka Server 없이도 테스트 컨텍스트가 부팅되도록 클라이언트 비활성화
+eureka:
+  client:
+    enabled: false
+    register-with-eureka: false
+    fetch-registry: false


### PR DESCRIPTION
## 관련 이슈
Closes #37

## 변경 유형
- [x] ✨ Feature
- [x] 🛠 Refactor / Chore
- [x] 📝 Docs

## 요약
gateway 의 백엔드 주소 하드코딩을 Eureka 기반 동적 서비스 디스커버리 + `lb://` LoadBalancer 라우팅으로 전환. ADR-003/004 적용으로 stateless 가 된 orderApi 를 수평 확장 가능한 상태로 만들기 위한 마지막 인프라 변경.

## 영향 받는 모듈
- [x] userApi
- [x] orderApi
- [x] gateway
- [x] infra (docker-compose)

## 동작 확인
**전체 테스트 그린**
- `./gradlew test -Dspring.redis.host=localhost -Dspring.redis.port=6379 -Dmailgun.apiKey=dummy -Dmailgun.domain=dummy.local` BUILD SUCCESSFUL
- `./gradlew :eurekaServer:build :gateway:build :orderApi:build :userApi:build -x test` BUILD SUCCESSFUL

**신규 통합 테스트**
- [`EurekaServerIntegrationTest`](eurekaServer/src/test/java/com/zerobase/eurekaserver/EurekaServerIntegrationTest.java) — Eureka REST API 의 register / discover / heartbeat / deregister 사이클을 실제 컨텍스트로 검증
- [`GatewayLoadBalancingIntegrationTest`](gateway/src/test/java/com/zerobase/gateway/GatewayLoadBalancingIntegrationTest.java) — `lb://order-api` 라우팅이 discovery 결과 (MockWebServer 2 개) 에 round-robin 분배되는지 검증

**테스트 격리**
- 본 통합 테스트들은 단일 JVM 안에서 완결 (Docker / 외부 인프라 불필요)
- 기존 컨텍스트 테스트는 `eureka.client.enabled=false` 로 Eureka Server 없이 부팅 가능

**docker-compose 검증** (별도 작업)
- 실제 다인스턴스 측정 (orderApi 1 → 2 → 4) 은 ADR-005 후속 작업으로 분리

## 주요 변경
- **신규 `eurekaServer` 모듈** — Spring Cloud Netflix Eureka Server (포트 8761), `enable-self-preservation: false` 로 측정 환경에서 인스턴스 추가/제거 빠른 반영
- **gateway**
  - `lb://order-api`, `lb://user-api` 라우팅 (하드코딩 주소 제거)
  - `spring-cloud-starter-netflix-eureka-client` + `spring-cloud-starter-loadbalancer` 의존성 추가
- **orderApi / userApi**
  - `spring.application.name` 명시 (각 `order-api`, `user-api`)
  - Eureka 클라이언트 등록 + `instance-id` 에 hostname 포함 (다인스턴스 식별)
- **docker-compose.test.yml**
  - `eureka` 서비스 추가 (curl 기반 healthcheck)
  - 모든 백엔드 서비스에 `EUREKA_SERVER_URL=http://eureka:8761/eureka/` 전달
  - 인스턴스당 자원 제한 `cpus: '4', memory: 2G` (ADR-005 비교 측정의 공정성)
  - orderApi 의 `container_name` / 호스트 port 바인딩 제거 → `docker compose up --scale orderapi=N` 가능

## 체크리스트
- [x] 단위 / 통합 테스트 통과 (`./gradlew test`)
- [x] DB 스키마 변경이 있다면 Flyway 마이그레이션 (`V_*.sql`) 추가 — 해당 없음
- [x] 두 모듈에 공유되는 DTO/Authority 등 변경 시 양쪽 모두 반영 — 해당 없음
- [x] 운영 yaml(`application.yml`)에 추가된 설정이 있다면 `application-test.yml` 및 `docker-compose.test.yml`에도 반영
- [x] 외부 API 추가/변경 시 Swagger 문서 갱신 — 해당 없음

## 후속 작업 (별도 PR)
- ADR-005 의 인스턴스 1 / 2 / 4 비교 측정 (k6 / JMeter, p99 · throughput · 분배 균등성)
- OutboxPoller 다인스턴스 중복 발행 방지 (분산 락 또는 `FOR UPDATE SKIP LOCKED`)
- Eureka Server 클러스터화 + 운영 시 DNS / VIP 추상화