### PR TITLE
feat(web): CUSTOMER flow API 연동 (Auth + 상품 + 장바구니 + 주문 + 잔액)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,8 @@ CLAUDE.md
 node_modules/
 dist/
 .turbo/
+.vite/
+*.tsbuildinfo
 *.log
 .pnpm-store/
 .env

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -5,9 +5,9 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "tsc -b && vite build",
+    "build": "tsc -p tsconfig.json --noEmit && tsc -p tsconfig.node.json --noEmit && vite build",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
-    "typecheck": "tsc -b --noEmit",
+    "typecheck": "tsc -p tsconfig.json --noEmit && tsc -p tsconfig.node.json --noEmit",
     "preview": "vite preview"
   },
   "dependencies": {
@@ -21,6 +21,7 @@
     "zod": "^4.4.3"
   },
   "devDependencies": {
+    "@types/node": "^25.9.1",
     "@types/react": "^18.3.12",
     "@types/react-dom": "^18.3.1",
     "@typescript-eslint/eslint-plugin": "^8.10.0",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -11,9 +11,14 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@hookform/resolvers": "^5.4.0",
+    "@tanstack/react-query": "^5.100.14",
+    "axios": "^1.16.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "react-router-dom": "^6.27.0"
+    "react-hook-form": "^7.76.1",
+    "react-router-dom": "^6.27.0",
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@types/react": "^18.3.12",

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -1,14 +1,26 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import { RouterProvider } from 'react-router-dom'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { router } from './router'
 import { AuthProvider } from './shared/auth/AuthContext'
 import './styles/index.css'
 
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      refetchOnWindowFocus: false,
+      retry: 1,
+    },
+  },
+})
+
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <AuthProvider>
-      <RouterProvider router={router} />
-    </AuthProvider>
+    <QueryClientProvider client={queryClient}>
+      <AuthProvider>
+        <RouterProvider router={router} />
+      </AuthProvider>
+    </QueryClientProvider>
   </StrictMode>,
 )

--- a/apps/web/src/router.tsx
+++ b/apps/web/src/router.tsx
@@ -4,6 +4,10 @@ import { CustomerHome } from './routes/customer/Home'
 import { CustomerProducts } from './routes/customer/Products'
 import { CustomerCart } from './routes/customer/Cart'
 import { CustomerOrders } from './routes/customer/Orders'
+import { CustomerLogin } from './routes/customer/Login'
+import { CustomerSignup } from './routes/customer/Signup'
+import { CustomerSignupVerify } from './routes/customer/SignupVerify'
+import { ProtectedRoute } from './shared/auth/ProtectedRoute'
 import { SellerLayout } from './routes/seller/Layout'
 import { SellerProducts } from './routes/seller/Products'
 import { SellerOrders } from './routes/seller/Orders'
@@ -15,9 +19,33 @@ export const router = createBrowserRouter([
     element: <CustomerLayout />,
     children: [
       { index: true, element: <CustomerHome /> },
-      { path: 'products', element: <CustomerProducts /> },
-      { path: 'cart', element: <CustomerCart /> },
-      { path: 'orders', element: <CustomerOrders /> },
+      { path: 'login', element: <CustomerLogin /> },
+      { path: 'signup', element: <CustomerSignup /> },
+      { path: 'signup/verify', element: <CustomerSignupVerify /> },
+      {
+        path: 'products',
+        element: (
+          <ProtectedRoute role="CUSTOMER">
+            <CustomerProducts />
+          </ProtectedRoute>
+        ),
+      },
+      {
+        path: 'cart',
+        element: (
+          <ProtectedRoute role="CUSTOMER">
+            <CustomerCart />
+          </ProtectedRoute>
+        ),
+      },
+      {
+        path: 'orders',
+        element: (
+          <ProtectedRoute role="CUSTOMER">
+            <CustomerOrders />
+          </ProtectedRoute>
+        ),
+      },
     ],
   },
   {

--- a/apps/web/src/router.tsx
+++ b/apps/web/src/router.tsx
@@ -2,8 +2,11 @@ import { createBrowserRouter, Navigate } from 'react-router-dom'
 import { CustomerLayout } from './routes/customer/Layout'
 import { CustomerHome } from './routes/customer/Home'
 import { CustomerProducts } from './routes/customer/Products'
+import { CustomerProductDetail } from './routes/customer/ProductDetail'
 import { CustomerCart } from './routes/customer/Cart'
 import { CustomerOrders } from './routes/customer/Orders'
+import { CustomerOrderDetail } from './routes/customer/OrderDetail'
+import { CustomerBalance } from './routes/customer/Balance'
 import { CustomerLogin } from './routes/customer/Login'
 import { CustomerSignup } from './routes/customer/Signup'
 import { CustomerSignupVerify } from './routes/customer/SignupVerify'
@@ -31,6 +34,14 @@ export const router = createBrowserRouter([
         ),
       },
       {
+        path: 'products/:id',
+        element: (
+          <ProtectedRoute role="CUSTOMER">
+            <CustomerProductDetail />
+          </ProtectedRoute>
+        ),
+      },
+      {
         path: 'cart',
         element: (
           <ProtectedRoute role="CUSTOMER">
@@ -43,6 +54,22 @@ export const router = createBrowserRouter([
         element: (
           <ProtectedRoute role="CUSTOMER">
             <CustomerOrders />
+          </ProtectedRoute>
+        ),
+      },
+      {
+        path: 'orders/:orderId',
+        element: (
+          <ProtectedRoute role="CUSTOMER">
+            <CustomerOrderDetail />
+          </ProtectedRoute>
+        ),
+      },
+      {
+        path: 'balance',
+        element: (
+          <ProtectedRoute role="CUSTOMER">
+            <CustomerBalance />
           </ProtectedRoute>
         ),
       },

--- a/apps/web/src/routes/customer/Balance.tsx
+++ b/apps/web/src/routes/customer/Balance.tsx
@@ -1,0 +1,58 @@
+import { useForm } from 'react-hook-form'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { z } from 'zod'
+import { useMutation } from '@tanstack/react-query'
+import { changeBalance } from '@/shared/api/balance'
+import { extractApiMessage } from '@/shared/api/client'
+
+const schema = z.object({
+  money: z.number().int().min(1, '1원 이상'),
+  message: z.string().min(1, '메모를 입력하세요'),
+  from: z.string().min(1, '출처를 입력하세요'),
+})
+type FormData = z.infer<typeof schema>
+
+export function CustomerBalance() {
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<FormData>({
+    resolver: zodResolver(schema),
+    defaultValues: { money: 10000, message: '충전', from: 'self' },
+  })
+
+  const mutation = useMutation({
+    mutationFn: changeBalance,
+  })
+
+  return (
+    <section>
+      <h1>잔액 충전</h1>
+      <form onSubmit={handleSubmit((d) => mutation.mutate(d))} className="form">
+        <label>
+          금액 (원)
+          <input type="number" {...register('money', { valueAsNumber: true })} />
+          {errors.money && <small className="err">{errors.money.message}</small>}
+        </label>
+        <label>
+          메모
+          <input {...register('message')} />
+          {errors.message && <small className="err">{errors.message.message}</small>}
+        </label>
+        <label>
+          출처
+          <input {...register('from')} />
+          {errors.from && <small className="err">{errors.from.message}</small>}
+        </label>
+        <button type="submit" disabled={mutation.isPending}>
+          {mutation.isPending ? '처리 중...' : '충전'}
+        </button>
+        {mutation.isError && <p className="err">{extractApiMessage(mutation.error)}</p>}
+        {mutation.isSuccess && (
+          <p className="ok">현재 잔액: {mutation.data.balance.toLocaleString()} 원</p>
+        )}
+      </form>
+    </section>
+  )
+}

--- a/apps/web/src/routes/customer/Cart.tsx
+++ b/apps/web/src/routes/customer/Cart.tsx
@@ -1,8 +1,136 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { Link, useNavigate } from 'react-router-dom'
+import { getCart, orderCart, updateCart } from '@/shared/api/cart'
+import { extractApiMessage } from '@/shared/api/client'
+import type { Cart } from '@/types/dto'
+
+function newIdempotencyKey(): string {
+  if (typeof crypto !== 'undefined' && 'randomUUID' in crypto) {
+    return crypto.randomUUID()
+  }
+  return `${Date.now()}-${Math.random().toString(36).slice(2)}`
+}
+
 export function CustomerCart() {
+  const queryClient = useQueryClient()
+  const navigate = useNavigate()
+
+  const cartQuery = useQuery({
+    queryKey: ['cart'],
+    queryFn: getCart,
+  })
+
+  const updateMutation = useMutation({
+    mutationFn: updateCart,
+    onSuccess: (next) => queryClient.setQueryData(['cart'], next),
+  })
+
+  const orderMutation = useMutation({
+    mutationFn: ({ cart, key }: { cart: Cart; key: string }) => orderCart(cart, key),
+    onSuccess: (res) => {
+      queryClient.invalidateQueries({ queryKey: ['cart'] })
+      const orderId = (res as { orderId?: number } | null)?.orderId
+      if (orderId) {
+        navigate(`/customer/orders/${orderId}`)
+      } else {
+        alert('주문이 접수되었습니다.')
+      }
+    },
+  })
+
+  if (cartQuery.isLoading) return <p>로딩...</p>
+  if (cartQuery.isError) return <p className="err">{extractApiMessage(cartQuery.error)}</p>
+
+  const cart = cartQuery.data
+  if (!cart || !cart.productList?.length) {
+    return (
+      <section>
+        <h1>장바구니</h1>
+        <p>
+          장바구니가 비어 있습니다. <Link to="/customer/products">상품 보러 가기</Link>
+        </p>
+      </section>
+    )
+  }
+
+  const updateItemCount = (productId: number, itemId: number, count: number) => {
+    const next: Cart = {
+      ...cart,
+      productList: cart.productList.map((p) =>
+        p.id !== productId
+          ? p
+          : {
+              ...p,
+              productItemList: p.productItemList.map((it) =>
+                it.id === itemId ? { ...it, count: Math.max(0, count) } : it,
+              ),
+            },
+      ),
+    }
+    updateMutation.mutate(next)
+  }
+
+  const onOrder = () => orderMutation.mutate({ cart, key: newIdempotencyKey() })
+
+  const total = cart.productList
+    .flatMap((p) => p.productItemList)
+    .reduce((sum, it) => sum + it.price * it.count, 0)
+
   return (
     <section>
       <h1>장바구니</h1>
-      <p>GET /api/customer/carts 연동 예정.</p>
+      {cart.messages && cart.messages.length > 0 && (
+        <ul className="err">
+          {cart.messages.map((m, i) => (
+            <li key={i}>{m}</li>
+          ))}
+        </ul>
+      )}
+      {cart.productList.map((p) => (
+        <div key={p.id} style={{ marginBottom: '1rem' }}>
+          <h3>{p.name}</h3>
+          <table className="table">
+            <thead>
+              <tr>
+                <th>옵션</th>
+                <th>가격</th>
+                <th>수량</th>
+                <th>소계</th>
+              </tr>
+            </thead>
+            <tbody>
+              {p.productItemList.map((it) => (
+                <tr key={it.id}>
+                  <td>{it.name}</td>
+                  <td>{it.price.toLocaleString()} 원</td>
+                  <td>
+                    <input
+                      type="number"
+                      min={0}
+                      value={it.count}
+                      onChange={(e) => updateItemCount(p.id, it.id, Number(e.target.value))}
+                      style={{ width: 80 }}
+                    />
+                  </td>
+                  <td>{(it.price * it.count).toLocaleString()} 원</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      ))}
+      <p>
+        <strong>합계: {total.toLocaleString()} 원</strong>
+      </p>
+      <button type="button" onClick={onOrder} disabled={orderMutation.isPending}>
+        {orderMutation.isPending ? '주문 중...' : '주문하기'}
+      </button>
+      {updateMutation.isError && (
+        <p className="err">{extractApiMessage(updateMutation.error)}</p>
+      )}
+      {orderMutation.isError && (
+        <p className="err">{extractApiMessage(orderMutation.error)}</p>
+      )}
     </section>
   )
 }

--- a/apps/web/src/routes/customer/Home.tsx
+++ b/apps/web/src/routes/customer/Home.tsx
@@ -1,8 +1,24 @@
+import { Link } from 'react-router-dom'
+import { useAuth } from '@/shared/auth/AuthContext'
+
 export function CustomerHome() {
+  const { user } = useAuth()
   return (
     <section>
       <h1>고객 홈</h1>
-      <p>상단 메뉴에서 상품/장바구니/주문 내역으로 이동하세요.</p>
+      {user ? (
+        <p>
+          <strong>{user.email}</strong> 님 환영합니다.{' '}
+          <Link to="/customer/products">상품 보러 가기 →</Link>
+        </p>
+      ) : (
+        <p>
+          <Link to="/customer/signup">회원가입</Link>
+          {' / '}
+          <Link to="/customer/login">로그인</Link>
+          {' 후 이용하세요.'}
+        </p>
+      )}
     </section>
   )
 }

--- a/apps/web/src/routes/customer/Layout.tsx
+++ b/apps/web/src/routes/customer/Layout.tsx
@@ -25,6 +25,8 @@ export function CustomerLayout() {
           {' | '}
           <Link to="/customer/orders">주문</Link>
           {' | '}
+          <Link to="/customer/balance">잔액</Link>
+          {' | '}
           <Link to="/seller">SELLER 모드 →</Link>
           <span style={{ float: 'right' }}>
             {user ? (

--- a/apps/web/src/routes/customer/Layout.tsx
+++ b/apps/web/src/routes/customer/Layout.tsx
@@ -1,6 +1,18 @@
-import { Link, Outlet } from 'react-router-dom'
+import { Link, Outlet, useLocation, useNavigate } from 'react-router-dom'
+import { useAuth } from '@/shared/auth/AuthContext'
 
 export function CustomerLayout() {
+  const { user, logout } = useAuth()
+  const navigate = useNavigate()
+  const location = useLocation()
+
+  const onLogout = () => {
+    logout()
+    navigate('/customer/login')
+  }
+
+  const onAuthPage = location.pathname.includes('/login') || location.pathname.includes('/signup')
+
   return (
     <div>
       <header>
@@ -11,9 +23,18 @@ export function CustomerLayout() {
           {' | '}
           <Link to="/customer/cart">장바구니</Link>
           {' | '}
-          <Link to="/customer/orders">주문 내역</Link>
+          <Link to="/customer/orders">주문</Link>
           {' | '}
           <Link to="/seller">SELLER 모드 →</Link>
+          <span style={{ float: 'right' }}>
+            {user ? (
+              <>
+                <span>{user.email}</span> <button type="button" onClick={onLogout}>로그아웃</button>
+              </>
+            ) : onAuthPage ? null : (
+              <Link to="/customer/login">로그인</Link>
+            )}
+          </span>
         </nav>
       </header>
       <main>

--- a/apps/web/src/routes/customer/Login.tsx
+++ b/apps/web/src/routes/customer/Login.tsx
@@ -1,0 +1,60 @@
+import { useForm } from 'react-hook-form'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { z } from 'zod'
+import { useMutation } from '@tanstack/react-query'
+import { Link, useLocation, useNavigate } from 'react-router-dom'
+import { loginCustomer } from '@/shared/api/auth'
+import { extractApiMessage } from '@/shared/api/client'
+import { useAuth } from '@/shared/auth/AuthContext'
+
+const schema = z.object({
+  email: z.email('올바른 이메일을 입력하세요'),
+  password: z.string().min(1, '비밀번호를 입력하세요'),
+})
+type FormData = z.infer<typeof schema>
+
+export function CustomerLogin() {
+  const { login } = useAuth()
+  const navigate = useNavigate()
+  const location = useLocation()
+  const from = (location.state as { from?: string } | null)?.from ?? '/customer'
+
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<FormData>({ resolver: zodResolver(schema) })
+
+  const loginMutation = useMutation({
+    mutationFn: loginCustomer,
+    onSuccess: (token) => {
+      login(token)
+      navigate(from, { replace: true })
+    },
+  })
+
+  return (
+    <section>
+      <h1>로그인 (CUSTOMER)</h1>
+      <form onSubmit={handleSubmit((data) => loginMutation.mutate(data))} className="form">
+        <label>
+          이메일
+          <input type="email" autoComplete="email" {...register('email')} />
+          {errors.email && <small className="err">{errors.email.message}</small>}
+        </label>
+        <label>
+          비밀번호
+          <input type="password" autoComplete="current-password" {...register('password')} />
+          {errors.password && <small className="err">{errors.password.message}</small>}
+        </label>
+        <button type="submit" disabled={loginMutation.isPending}>
+          {loginMutation.isPending ? '로그인 중...' : '로그인'}
+        </button>
+        {loginMutation.isError && <p className="err">{extractApiMessage(loginMutation.error)}</p>}
+      </form>
+      <p>
+        계정이 없나요? <Link to="/customer/signup">회원가입</Link>
+      </p>
+    </section>
+  )
+}

--- a/apps/web/src/routes/customer/OrderDetail.tsx
+++ b/apps/web/src/routes/customer/OrderDetail.tsx
@@ -1,0 +1,67 @@
+import { useQuery } from '@tanstack/react-query'
+import { useParams } from 'react-router-dom'
+import { getOrder } from '@/shared/api/order'
+import { extractApiMessage } from '@/shared/api/client'
+import type { OrderStatus } from '@/types/dto'
+
+const statusLabel: Record<OrderStatus, string> = {
+  PENDING: '주문 처리 중',
+  PAID: '결제 완료 (재고 확정 대기)',
+  CONFIRMED: '주문 확정',
+  FAILED: '주문 실패',
+}
+
+export function CustomerOrderDetail() {
+  const { orderId } = useParams<{ orderId: string }>()
+  const id = Number(orderId)
+
+  const { data, isLoading, isError, error } = useQuery({
+    queryKey: ['order', id],
+    queryFn: () => getOrder(id),
+    enabled: Number.isFinite(id) && id > 0,
+    // ADR-003 SAGA 진행 중인 PENDING/PAID 상태에선 2 초 폴링
+    refetchInterval: (q) => {
+      const d = q.state.data
+      return d && (d.status === 'PENDING' || d.status === 'PAID') ? 2000 : false
+    },
+  })
+
+  if (isLoading) return <p>로딩...</p>
+  if (isError) return <p className="err">{extractApiMessage(error)}</p>
+  if (!data) return <p>주문 없음</p>
+
+  return (
+    <section>
+      <h1>주문 #{data.orderId}</h1>
+      <p>
+        상태: <strong>{statusLabel[data.status] ?? data.status}</strong>
+      </p>
+      {data.failureReason && <p className="err">실패 사유: {data.failureReason}</p>}
+
+      <h2>주문 항목</h2>
+      <table className="table">
+        <thead>
+          <tr>
+            <th>상품</th>
+            <th>수량</th>
+            <th>가격</th>
+            <th>소계</th>
+          </tr>
+        </thead>
+        <tbody>
+          {data.items.map((it) => (
+            <tr key={it.productItemId}>
+              <td>{it.name}</td>
+              <td>{it.count}</td>
+              <td>{it.price.toLocaleString()} 원</td>
+              <td>{(it.count * it.price).toLocaleString()} 원</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      <p>
+        <strong>총액: {data.totalPrice.toLocaleString()} 원</strong>
+      </p>
+    </section>
+  )
+}

--- a/apps/web/src/routes/customer/Orders.tsx
+++ b/apps/web/src/routes/customer/Orders.tsx
@@ -1,8 +1,36 @@
+import { useForm } from 'react-hook-form'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { z } from 'zod'
+import { useNavigate } from 'react-router-dom'
+
+const schema = z.object({
+  orderId: z.string().regex(/^\d+$/, '숫자만 입력하세요'),
+})
+type FormData = z.infer<typeof schema>
+
 export function CustomerOrders() {
+  const navigate = useNavigate()
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<FormData>({ resolver: zodResolver(schema) })
+
   return (
     <section>
-      <h1>주문 내역</h1>
-      <p>GET /api/customer/orders 연동 예정.</p>
+      <h1>주문 조회</h1>
+      <p>주문 ID 로 주문 상세를 조회합니다. (백엔드에 주문 목록 API 가 아직 없음 — 주문 후 받은 ID 입력)</p>
+      <form
+        onSubmit={handleSubmit((d) => navigate(`/customer/orders/${d.orderId}`))}
+        className="form"
+      >
+        <label>
+          주문 ID
+          <input inputMode="numeric" {...register('orderId')} />
+          {errors.orderId && <small className="err">{errors.orderId.message}</small>}
+        </label>
+        <button type="submit">조회</button>
+      </form>
     </section>
   )
 }

--- a/apps/web/src/routes/customer/ProductDetail.tsx
+++ b/apps/web/src/routes/customer/ProductDetail.tsx
@@ -1,0 +1,98 @@
+import { useState } from 'react'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { useNavigate, useParams } from 'react-router-dom'
+import { getProductDetail } from '@/shared/api/search'
+import { addCart } from '@/shared/api/cart'
+import { extractApiMessage } from '@/shared/api/client'
+import type { AddProductCartForm } from '@/types/dto'
+
+export function CustomerProductDetail() {
+  const { id } = useParams<{ id: string }>()
+  const productId = Number(id)
+  const navigate = useNavigate()
+  const queryClient = useQueryClient()
+
+  const [counts, setCounts] = useState<Record<number, number>>({})
+
+  const { data, isLoading, isError, error } = useQuery({
+    queryKey: ['product', productId],
+    queryFn: () => getProductDetail(productId),
+    enabled: Number.isFinite(productId) && productId > 0,
+  })
+
+  const addToCart = useMutation({
+    mutationFn: (form: AddProductCartForm) => addCart(form),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['cart'] })
+      navigate('/customer/cart')
+    },
+  })
+
+  if (isLoading) return <p>로딩...</p>
+  if (isError) return <p className="err">{extractApiMessage(error)}</p>
+  if (!data) return <p>상품을 찾을 수 없습니다.</p>
+
+  const onAddToCart = () => {
+    const items = (data.productItemList ?? [])
+      .map((it) => ({ ...it, count: counts[it.id] ?? 0 }))
+      .filter((it) => it.count > 0)
+    if (items.length === 0) {
+      alert('수량을 1개 이상 입력하세요.')
+      return
+    }
+    addToCart.mutate({
+      id: data.id,
+      // ProductDto 응답에 sellerId 가 없어 0 으로 전송. 백엔드가 product id 로 채워주는 형태 가정.
+      sellerId: 0,
+      name: data.name,
+      description: data.description,
+      productItemList: items,
+    })
+  }
+
+  return (
+    <section>
+      <h1>{data.name}</h1>
+      <p className="muted">{data.description}</p>
+      <h2>옵션</h2>
+      <table className="table">
+        <thead>
+          <tr>
+            <th>옵션명</th>
+            <th>가격</th>
+            <th>재고</th>
+            <th>담을 수량</th>
+          </tr>
+        </thead>
+        <tbody>
+          {(data.productItemList ?? []).map((it) => (
+            <tr key={it.id}>
+              <td>{it.name}</td>
+              <td>{it.price.toLocaleString()} 원</td>
+              <td>{it.count}</td>
+              <td>
+                <input
+                  type="number"
+                  min={0}
+                  max={it.count}
+                  value={counts[it.id] ?? 0}
+                  onChange={(e) =>
+                    setCounts((prev) => ({
+                      ...prev,
+                      [it.id]: Math.max(0, Math.min(it.count, Number(e.target.value))),
+                    }))
+                  }
+                  style={{ width: 80 }}
+                />
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      <button type="button" onClick={onAddToCart} disabled={addToCart.isPending}>
+        {addToCart.isPending ? '담는 중...' : '장바구니 담기'}
+      </button>
+      {addToCart.isError && <p className="err">{extractApiMessage(addToCart.error)}</p>}
+    </section>
+  )
+}

--- a/apps/web/src/routes/customer/Products.tsx
+++ b/apps/web/src/routes/customer/Products.tsx
@@ -1,8 +1,61 @@
+import { useState } from 'react'
+import { useForm } from 'react-hook-form'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { z } from 'zod'
+import { useQuery } from '@tanstack/react-query'
+import { Link } from 'react-router-dom'
+import { searchProductsByName } from '@/shared/api/search'
+import { extractApiMessage } from '@/shared/api/client'
+
+const schema = z.object({
+  name: z.string().min(1, '검색어를 입력하세요'),
+})
+type FormData = z.infer<typeof schema>
+
 export function CustomerProducts() {
+  const [query, setQuery] = useState('')
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<FormData>({ resolver: zodResolver(schema) })
+
+  const { data, isLoading, isError, error, isFetching } = useQuery({
+    queryKey: ['searchProducts', query],
+    queryFn: () => searchProductsByName(query),
+    enabled: query.length > 0,
+  })
+
   return (
     <section>
-      <h1>상품 목록</h1>
-      <p>GET /api/customer/products 연동 예정.</p>
+      <h1>상품 검색</h1>
+      <form onSubmit={handleSubmit((d) => setQuery(d.name))} className="form">
+        <label>
+          상품명
+          <input {...register('name')} placeholder="예: 노트북" />
+          {errors.name && <small className="err">{errors.name.message}</small>}
+        </label>
+        <button type="submit">검색</button>
+      </form>
+
+      {query && (isLoading || isFetching) && <p>검색 중...</p>}
+      {isError && <p className="err">{extractApiMessage(error)}</p>}
+      {data &&
+        (data.length === 0 ? (
+          <p>검색 결과가 없습니다.</p>
+        ) : (
+          <ul className="card-list">
+            {data.map((p) => (
+              <li key={p.id} className="card">
+                <h3>
+                  <Link to={`/customer/products/${p.id}`}>{p.name}</Link>
+                </h3>
+                <p className="muted">{p.description}</p>
+                <p className="muted">옵션 {p.productItemList?.length ?? 0}개</p>
+              </li>
+            ))}
+          </ul>
+        ))}
     </section>
   )
 }

--- a/apps/web/src/routes/customer/Signup.tsx
+++ b/apps/web/src/routes/customer/Signup.tsx
@@ -1,0 +1,74 @@
+import { useForm } from 'react-hook-form'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { z } from 'zod'
+import { useMutation } from '@tanstack/react-query'
+import { Link, useNavigate } from 'react-router-dom'
+import { signupCustomer } from '@/shared/api/auth'
+import { extractApiMessage } from '@/shared/api/client'
+
+const schema = z.object({
+  email: z.email('올바른 이메일을 입력하세요'),
+  name: z.string().min(1, '이름을 입력하세요'),
+  password: z.string().min(8, '비밀번호는 8자 이상'),
+  birth: z.string().regex(/^\d{4}-\d{2}-\d{2}$/, 'YYYY-MM-DD 형식'),
+  phoneNum: z.string().min(1, '전화번호를 입력하세요'),
+})
+type FormData = z.infer<typeof schema>
+
+export function CustomerSignup() {
+  const navigate = useNavigate()
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+    getValues,
+  } = useForm<FormData>({ resolver: zodResolver(schema) })
+
+  const signupMutation = useMutation({
+    mutationFn: signupCustomer,
+    onSuccess: () => {
+      const { email } = getValues()
+      navigate(`/customer/signup/verify?email=${encodeURIComponent(email)}`)
+    },
+  })
+
+  return (
+    <section>
+      <h1>회원가입 (CUSTOMER)</h1>
+      <form onSubmit={handleSubmit((data) => signupMutation.mutate(data))} className="form">
+        <label>
+          이메일
+          <input type="email" autoComplete="email" {...register('email')} />
+          {errors.email && <small className="err">{errors.email.message}</small>}
+        </label>
+        <label>
+          이름
+          <input autoComplete="name" {...register('name')} />
+          {errors.name && <small className="err">{errors.name.message}</small>}
+        </label>
+        <label>
+          비밀번호 (8자 이상)
+          <input type="password" autoComplete="new-password" {...register('password')} />
+          {errors.password && <small className="err">{errors.password.message}</small>}
+        </label>
+        <label>
+          생년월일 (YYYY-MM-DD)
+          <input placeholder="1990-01-01" {...register('birth')} />
+          {errors.birth && <small className="err">{errors.birth.message}</small>}
+        </label>
+        <label>
+          전화번호
+          <input autoComplete="tel" placeholder="010-1234-5678" {...register('phoneNum')} />
+          {errors.phoneNum && <small className="err">{errors.phoneNum.message}</small>}
+        </label>
+        <button type="submit" disabled={signupMutation.isPending}>
+          {signupMutation.isPending ? '가입 중...' : '가입 신청'}
+        </button>
+        {signupMutation.isError && <p className="err">{extractApiMessage(signupMutation.error)}</p>}
+      </form>
+      <p>
+        이미 가입했나요? <Link to="/customer/login">로그인</Link>
+      </p>
+    </section>
+  )
+}

--- a/apps/web/src/routes/customer/SignupVerify.tsx
+++ b/apps/web/src/routes/customer/SignupVerify.tsx
@@ -1,0 +1,56 @@
+import { useForm } from 'react-hook-form'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { z } from 'zod'
+import { useMutation } from '@tanstack/react-query'
+import { useNavigate, useSearchParams } from 'react-router-dom'
+import { verifyCustomerEmail } from '@/shared/api/auth'
+import { extractApiMessage } from '@/shared/api/client'
+
+const schema = z.object({
+  email: z.email('올바른 이메일을 입력하세요'),
+  code: z.string().min(1, '인증코드를 입력하세요'),
+})
+type FormData = z.infer<typeof schema>
+
+export function CustomerSignupVerify() {
+  const [params] = useSearchParams()
+  const defaultEmail = params.get('email') ?? ''
+  const navigate = useNavigate()
+
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<FormData>({
+    resolver: zodResolver(schema),
+    defaultValues: { email: defaultEmail, code: '' },
+  })
+
+  const verifyMutation = useMutation({
+    mutationFn: (data: FormData) => verifyCustomerEmail(data.email, data.code),
+    onSuccess: () => navigate('/customer/login'),
+  })
+
+  return (
+    <section>
+      <h1>이메일 인증</h1>
+      <p>가입 시 등록한 이메일로 받은 인증코드를 입력하세요.</p>
+      <form onSubmit={handleSubmit((data) => verifyMutation.mutate(data))} className="form">
+        <label>
+          이메일
+          <input type="email" {...register('email')} />
+          {errors.email && <small className="err">{errors.email.message}</small>}
+        </label>
+        <label>
+          인증코드
+          <input {...register('code')} />
+          {errors.code && <small className="err">{errors.code.message}</small>}
+        </label>
+        <button type="submit" disabled={verifyMutation.isPending}>
+          {verifyMutation.isPending ? '인증 중...' : '인증 완료'}
+        </button>
+        {verifyMutation.isError && <p className="err">{extractApiMessage(verifyMutation.error)}</p>}
+      </form>
+    </section>
+  )
+}

--- a/apps/web/src/shared/api/auth.ts
+++ b/apps/web/src/shared/api/auth.ts
@@ -1,0 +1,21 @@
+import { api } from './client'
+import type { SignupInput, SignupOutput, SigninInput } from '@/types/dto'
+
+// nginx /api/user/customer/signup → gateway /user/customer/signup → user-api /customer/signup
+export async function signupCustomer(input: SignupInput): Promise<SignupOutput> {
+  const { data } = await api.post<SignupOutput>('/user/customer/signup', input)
+  return data
+}
+
+export async function verifyCustomerEmail(email: string, code: string): Promise<SignupOutput> {
+  const { data } = await api.put<SignupOutput>('/user/customer/signup/verify', null, {
+    params: { email, code },
+  })
+  return data
+}
+
+// 응답 body 가 JWT 문자열
+export async function loginCustomer(input: SigninInput): Promise<string> {
+  const { data } = await api.post<string>('/user/customer/login', input)
+  return data
+}

--- a/apps/web/src/shared/api/balance.ts
+++ b/apps/web/src/shared/api/balance.ts
@@ -1,0 +1,7 @@
+import { api } from './client'
+import type { ChangeBalanceInput, ChangeBalanceOutput } from '@/types/dto'
+
+export async function changeBalance(input: ChangeBalanceInput): Promise<ChangeBalanceOutput> {
+  const { data } = await api.post<ChangeBalanceOutput>('/user/customer/balance', input)
+  return data
+}

--- a/apps/web/src/shared/api/cart.ts
+++ b/apps/web/src/shared/api/cart.ts
@@ -1,0 +1,25 @@
+import { api } from './client'
+import type { AddProductCartForm, Cart } from '@/types/dto'
+
+export async function getCart(): Promise<Cart> {
+  const { data } = await api.get<Cart>('/order/customer/cart')
+  return data
+}
+
+export async function addCart(form: AddProductCartForm): Promise<Cart> {
+  const { data } = await api.post<Cart>('/order/customer/cart', form)
+  return data
+}
+
+export async function updateCart(cart: Cart): Promise<Cart> {
+  const { data } = await api.put<Cart>('/order/customer/cart', cart)
+  return data
+}
+
+// ADR-001: Idempotency-Key 헤더로 중복 주문 방지
+export async function orderCart(cart: Cart, idempotencyKey: string): Promise<unknown> {
+  const { data } = await api.post('/order/customer/cart/order', cart, {
+    headers: { 'Idempotency-Key': idempotencyKey },
+  })
+  return data
+}

--- a/apps/web/src/shared/api/client.ts
+++ b/apps/web/src/shared/api/client.ts
@@ -1,22 +1,45 @@
+import axios, { AxiosError, type AxiosInstance } from 'axios'
+
 const BASE_URL = import.meta.env.VITE_API_BASE_URL ?? '/api'
+export const TOKEN_KEY = 'commerce-token'
 
-export type ApiError = {
-  status: number
-  message: string
-}
+export const api: AxiosInstance = axios.create({
+  baseURL: BASE_URL,
+  headers: { 'Content-Type': 'application/json' },
+})
 
-export async function apiFetch<T>(path: string, init?: RequestInit): Promise<T> {
-  const res = await fetch(`${BASE_URL}${path}`, {
-    ...init,
-    headers: {
-      'Content-Type': 'application/json',
-      ...(init?.headers ?? {}),
-    },
-  })
-  if (!res.ok) {
-    const message = await res.text().catch(() => res.statusText)
-    throw { status: res.status, message } satisfies ApiError
+api.interceptors.request.use((config) => {
+  const token = localStorage.getItem(TOKEN_KEY)
+  if (token) config.headers.Authorization = `Bearer ${token}`
+  return config
+})
+
+api.interceptors.response.use(
+  (res) => res,
+  (err: AxiosError) => {
+    if (err.response?.status === 401) {
+      localStorage.removeItem(TOKEN_KEY)
+      const path = window.location.pathname
+      // login/signup 화면이 아니면 로그인 페이지로
+      const isAuthPage = path.includes('/login') || path.includes('/signup')
+      if (path.startsWith('/customer') && !isAuthPage) {
+        window.location.href = '/customer/login'
+      }
+    }
+    return Promise.reject(err)
+  },
+)
+
+// 백엔드 에러 응답에서 사용자에게 보여줄 메시지 추출
+export function extractApiMessage(err: unknown): string {
+  if (axios.isAxiosError(err)) {
+    const data = err.response?.data
+    if (typeof data === 'string') return data
+    if (data && typeof data === 'object') {
+      const msg = (data as { message?: string }).message
+      if (msg) return msg
+    }
+    return err.message
   }
-  if (res.status === 204) return undefined as T
-  return res.json() as Promise<T>
+  return err instanceof Error ? err.message : 'Unknown error'
 }

--- a/apps/web/src/shared/api/order.ts
+++ b/apps/web/src/shared/api/order.ts
@@ -1,0 +1,7 @@
+import { api } from './client'
+import type { OrderDto } from '@/types/dto'
+
+export async function getOrder(orderId: number): Promise<OrderDto> {
+  const { data } = await api.get<OrderDto>(`/order/customer/orders/${orderId}`)
+  return data
+}

--- a/apps/web/src/shared/api/search.ts
+++ b/apps/web/src/shared/api/search.ts
@@ -1,0 +1,17 @@
+import { api } from './client'
+import type { ProductDto } from '@/types/dto'
+
+// nginx /api/order/search/product?name=
+export async function searchProductsByName(name: string): Promise<ProductDto[]> {
+  const { data } = await api.get<ProductDto[]>('/order/search/product', {
+    params: { name },
+  })
+  return data
+}
+
+export async function getProductDetail(productId: number): Promise<ProductDto> {
+  const { data } = await api.get<ProductDto>('/order/search/product/detail', {
+    params: { productId },
+  })
+  return data
+}

--- a/apps/web/src/shared/auth/AuthContext.tsx
+++ b/apps/web/src/shared/auth/AuthContext.tsx
@@ -1,31 +1,70 @@
-import { createContext, useContext, useMemo, useState, type PropsWithChildren } from 'react'
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+  type PropsWithChildren,
+} from 'react'
+import { TOKEN_KEY } from '../api/client'
+import { decodeJwt, isExpired, type JwtPayload } from './jwt'
 
 export type Role = 'CUSTOMER' | 'SELLER'
 
-export type AuthUser = {
+export interface AuthUser {
   email: string
-  role: Role
-  token: string
+  roles: Role[]
+  id?: number
 }
 
-type AuthContextValue = {
+interface AuthContextValue {
+  token: string | null
   user: AuthUser | null
-  login: (user: AuthUser) => void
+  login: (token: string) => void
   logout: () => void
 }
 
 const AuthContext = createContext<AuthContextValue | null>(null)
 
-export function AuthProvider({ children }: PropsWithChildren) {
-  const [user, setUser] = useState<AuthUser | null>(null)
-  const value = useMemo<AuthContextValue>(
-    () => ({
-      user,
-      login: setUser,
-      logout: () => setUser(null),
-    }),
-    [user],
+function payloadToUser(payload: JwtPayload | null): AuthUser | null {
+  if (!payload) return null
+  const email = payload.email ?? payload.sub
+  if (!email) return null
+  const roles = (payload.roles ?? []).map((r) =>
+    r.startsWith('ROLE_') ? (r.slice(5) as Role) : (r as Role),
   )
+  return { email, roles, id: payload.id }
+}
+
+export function AuthProvider({ children }: PropsWithChildren) {
+  const [token, setToken] = useState<string | null>(() => localStorage.getItem(TOKEN_KEY))
+
+  // 부팅 시 만료 토큰 정리
+  useEffect(() => {
+    if (token && isExpired(decodeJwt(token))) {
+      localStorage.removeItem(TOKEN_KEY)
+      setToken(null)
+    }
+  }, [token])
+
+  const login = useCallback((nextToken: string) => {
+    localStorage.setItem(TOKEN_KEY, nextToken)
+    setToken(nextToken)
+  }, [])
+
+  const logout = useCallback(() => {
+    localStorage.removeItem(TOKEN_KEY)
+    setToken(null)
+  }, [])
+
+  const user = useMemo(() => payloadToUser(decodeJwt(token ?? '')), [token])
+
+  const value = useMemo<AuthContextValue>(
+    () => ({ token, user, login, logout }),
+    [token, user, login, logout],
+  )
+
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>
 }
 

--- a/apps/web/src/shared/auth/ProtectedRoute.tsx
+++ b/apps/web/src/shared/auth/ProtectedRoute.tsx
@@ -1,0 +1,23 @@
+import { Navigate, useLocation } from 'react-router-dom'
+import { type PropsWithChildren } from 'react'
+import { useAuth, type Role } from './AuthContext'
+
+interface Props extends PropsWithChildren {
+  role?: Role
+  loginPath?: string
+}
+
+export function ProtectedRoute({ children, role, loginPath = '/customer/login' }: Props) {
+  const { user } = useAuth()
+  const location = useLocation()
+
+  if (!user) {
+    return <Navigate to={loginPath} state={{ from: location.pathname }} replace />
+  }
+
+  if (role && !user.roles.includes(role)) {
+    return <Navigate to="/" replace />
+  }
+
+  return <>{children}</>
+}

--- a/apps/web/src/shared/auth/jwt.ts
+++ b/apps/web/src/shared/auth/jwt.ts
@@ -1,0 +1,34 @@
+// JWT payload 디코드 (서명 검증 없음). 라이브러리 추가 회피용 미니멀.
+export interface JwtPayload {
+  sub?: string
+  email?: string
+  roles?: string[]
+  id?: number
+  exp?: number
+  iat?: number
+  [k: string]: unknown
+}
+
+export function decodeJwt(token: string): JwtPayload | null {
+  try {
+    const payload = token.split('.')[1]
+    if (!payload) return null
+    const base64 = payload.replace(/-/g, '+').replace(/_/g, '/')
+    const padded = base64 + '=='.slice(0, (4 - (base64.length % 4)) % 4)
+    const decoded = atob(padded)
+    const json = decodeURIComponent(
+      decoded
+        .split('')
+        .map((c) => '%' + c.charCodeAt(0).toString(16).padStart(2, '0'))
+        .join(''),
+    )
+    return JSON.parse(json) as JwtPayload
+  } catch {
+    return null
+  }
+}
+
+export function isExpired(payload: JwtPayload | null): boolean {
+  if (!payload?.exp) return false
+  return Date.now() >= payload.exp * 1000
+}

--- a/apps/web/src/styles/index.css
+++ b/apps/web/src/styles/index.css
@@ -32,3 +32,84 @@ main {
 h1 {
   margin-top: 0;
 }
+
+/* Form */
+.form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  max-width: 420px;
+}
+.form label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+.form input,
+.form select,
+.form textarea {
+  padding: 0.5rem;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  font-size: 1rem;
+}
+.form button {
+  padding: 0.5rem 1rem;
+  font-size: 1rem;
+  cursor: pointer;
+  border: 1px solid #646cff;
+  background: #646cff;
+  color: white;
+  border-radius: 4px;
+}
+.form button:disabled {
+  background: #aaa;
+  border-color: #aaa;
+  cursor: not-allowed;
+}
+.err {
+  color: #c62828;
+  font-size: 0.85rem;
+}
+.ok {
+  color: #2e7d32;
+  font-size: 0.95rem;
+}
+
+/* Product card list */
+.card-list {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+  gap: 1rem;
+  margin-top: 1rem;
+}
+.card {
+  border: 1px solid #e0e0e0;
+  border-radius: 6px;
+  padding: 1rem;
+  background: #fafafa;
+}
+.card h3 {
+  margin: 0 0 0.5rem;
+  font-size: 1rem;
+}
+.card .muted {
+  color: #666;
+  font-size: 0.85rem;
+}
+
+/* Table */
+.table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-top: 1rem;
+}
+.table th,
+.table td {
+  border: 1px solid #e0e0e0;
+  padding: 0.5rem;
+  text-align: left;
+}
+.table th {
+  background: #f5f5f5;
+}

--- a/apps/web/src/types/dto.ts
+++ b/apps/web/src/types/dto.ts
@@ -1,0 +1,92 @@
+// 백엔드 DTO 미러.
+// gateway 경로: /api/user/* → user-api, /api/order/* → order-api (nginx 프록시 경유)
+
+// ===== user-api =====
+export interface SignupInput {
+  email: string
+  name: string
+  password: string
+  birth: string // YYYY-MM-DD (LocalDate)
+  phoneNum: string
+}
+
+export interface SignupOutput {
+  message: string
+}
+
+export interface SigninInput {
+  email: string
+  password: string
+}
+// POST /customer/login 응답은 body 가 JWT 문자열
+
+export interface ChangeBalanceInput {
+  money: number
+  message: string
+  from: string
+}
+
+export interface ChangeBalanceOutput {
+  balance: number
+}
+
+// ===== order-api =====
+export interface ProductItemDto {
+  id: number
+  name: string
+  price: number
+  count: number
+}
+
+export interface ProductDto {
+  id: number
+  name: string
+  description: string
+  productItemList: ProductItemDto[]
+}
+
+export interface AddProductCartForm {
+  id: number // product id
+  sellerId: number
+  name: string
+  description: string
+  productItemList: ProductItemDto[]
+}
+
+export interface CartProductItem {
+  id: number
+  name: string
+  count: number
+  price: number
+}
+
+export interface CartProduct {
+  id: number
+  sellerId: number
+  name: string
+  description: string
+  productItemList: CartProductItem[]
+}
+
+export interface Cart {
+  customerId: number
+  productList: CartProduct[]
+  messages: string[]
+}
+
+export type OrderStatus = 'PENDING' | 'PAID' | 'CONFIRMED' | 'FAILED'
+
+export interface OrderItem {
+  productItemId: number
+  name: string
+  count: number
+  price: number
+}
+
+export interface OrderDto {
+  orderId: number
+  status: OrderStatus
+  totalPrice: number
+  failureReason: string | null
+  items: OrderItem[]
+}

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -21,6 +21,5 @@
       "@/*": ["src/*"]
     }
   },
-  "include": ["src"],
-  "references": [{ "path": "./tsconfig.node.json" }]
+  "include": ["src"]
 }

--- a/apps/web/tsconfig.node.json
+++ b/apps/web/tsconfig.node.json
@@ -1,11 +1,13 @@
 {
   "compilerOptions": {
-    "composite": true,
-    "skipLibCheck": true,
+    "target": "ES2022",
     "module": "ESNext",
     "moduleResolution": "bundler",
     "allowSyntheticDefaultImports": true,
-    "strict": true
+    "strict": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "types": ["node"]
   },
   "include": ["vite.config.ts"]
 }

--- a/docs/customer-flow.md
+++ b/docs/customer-flow.md
@@ -1,0 +1,253 @@
+# CUSTOMER Flow
+
+`apps/web` 의 CUSTOMER 화면과 백엔드(user-api / order-api) 사이의 전체 흐름을 swim lane 형식의 flowchart 와 시나리오별 sequence diagram 으로 정리한다.
+
+> 화면 구현: [#43](https://github.com/jameskim9509/CommerceAPI/issues/43) / [#44](https://github.com/jameskim9509/CommerceAPI/pull/44)
+> 게이트웨이 라우팅: `/api/user/**` → user-api, `/api/order/**` → order-api (nginx → gateway, ADR-005 Eureka LB)
+
+---
+
+## 1. 전체 구성 (Swim Lane)
+
+각 swim lane = subgraph. 노드는 책임/역할 단위로 묶었고, 점선은 부수 효과(토큰 주입, 캐시 무효화)다.
+
+```mermaid
+flowchart LR
+  subgraph User["👤 사용자 (Browser)"]
+    direction TB
+    U1[페이지 진입]
+    U2[폼 작성/제출]
+    U3[상품 검색·담기·주문]
+    U4[주문 상세 확인]
+  end
+
+  subgraph SPA["⚛️ apps/web (React SPA)"]
+    direction TB
+    S1[React Router 라우팅]
+    S6[ProtectedRoute 가드]
+    S2[react-hook-form + zod 검증]
+    S3[TanStack Query<br/>useQuery / useMutation]
+    S5[AuthContext<br/>localStorage 동기화]
+    S4[axios interceptor<br/>JWT 자동 주입]
+  end
+
+  subgraph Nginx["🟢 nginx (web 컨테이너)"]
+    direction TB
+    N1[SPA 정적 파일 서빙<br/>SPA fallback try_files]
+    N2["/api/* → gateway:80 프록시"]
+  end
+
+  subgraph GW["🚪 Spring Cloud Gateway"]
+    direction TB
+    G1["/user/** → lb://user-api"]
+    G2["/order/** → lb://order-api"]
+  end
+
+  subgraph UA["🧑 user-api"]
+    direction TB
+    UA1[POST /customer/signup<br/>이메일 코드 발송]
+    UA2[PUT /customer/signup/verify]
+    UA3[POST /customer/login<br/>JWT 발급]
+    UA4[POST /customer/balance]
+  end
+
+  subgraph OA["📦 order-api"]
+    direction TB
+    OA1[GET /search/product, /search/product/detail]
+    OA3[GET/POST/PUT /customer/cart]
+    OA4[POST /customer/cart/order<br/>Idempotency-Key]
+    OA5[GET /customer/orders/:id]
+  end
+
+  subgraph Infra["💾 인프라"]
+    direction TB
+    I1[(MySQL: user)]
+    I2[(MySQL: order)]
+    I3[(Redis<br/>장바구니 · 멱등성)]
+    I4{{Kafka<br/>SAGA topics}}
+  end
+
+  U1 --> S1
+  U2 --> S2 --> S3
+  U3 --> S3
+  U4 --> S3
+  S1 --> S6
+  S3 --> S4
+  S5 -.토큰 read.-> S4
+  S4 ==HTTP==> N2
+  N1 --> S1
+  N2 --> G1
+  N2 --> G2
+  G1 --> UA1
+  G1 --> UA2
+  G1 --> UA3
+  G1 --> UA4
+  G2 --> OA1
+  G2 --> OA3
+  G2 --> OA4
+  G2 --> OA5
+  UA1 --> I1
+  UA2 --> I1
+  UA3 --> I1
+  UA4 --> I1
+  OA1 --> I2
+  OA3 --> I3
+  OA4 --> I3
+  OA4 --> I4
+  OA5 --> I2
+  S3 -.invalidate.-> S3
+```
+
+**핵심 포인트**
+- SPA 안의 모든 외부 호출은 `axios` 한 인스턴스를 거치고, **요청 인터셉터가 `localStorage` 의 JWT 를 `Bearer` 로 자동 주입**한다 (`apps/web/src/shared/api/client.ts`).
+- 401 응답 시 인터셉터가 토큰을 지우고 `/customer/login` 으로 리다이렉트한다.
+- `nginx` 는 SPA 정적 산출물 서빙과 `/api/*` 프록시 두 역할만 한다 (인증 처리 없음).
+- gateway 는 service-id 기반 (`lb://user-api`, `lb://order-api`) 로라 Eureka 에서 인스턴스를 동적 발견한다 (ADR-005).
+
+---
+
+## 2. 시나리오별 시퀀스
+
+회원가입부터 주문 상세 폴링까지의 시간 흐름. participant 가 swim lane 역할이고, `Note` 가 사이드 이펙트다.
+
+```mermaid
+sequenceDiagram
+  autonumber
+  actor User as 👤 User
+  participant SPA as ⚛️ apps/web
+  participant Nginx as 🟢 nginx
+  participant GW as 🚪 gateway
+  participant UA as 🧑 user-api
+  participant OA as 📦 order-api
+  participant DB as 💾 DB/Redis
+  participant K as 🟧 Kafka
+
+  rect rgb(240, 248, 255)
+    Note over User,UA: 1. 회원가입 + 이메일 인증
+    User->>SPA: 회원가입 폼 제출
+    SPA->>SPA: zod 검증 통과
+    SPA->>Nginx: POST /api/user/customer/signup
+    Nginx->>GW: POST /user/customer/signup
+    GW->>UA: POST /customer/signup
+    UA->>DB: Customer 저장 + 인증코드 발송
+    UA-->>SPA: { message }
+    SPA->>SPA: /customer/signup/verify?email= 이동
+
+    User->>SPA: 인증코드 입력 / 제출
+    SPA->>Nginx: PUT /api/user/customer/signup/verify?email=&code=
+    Nginx->>GW: 동일
+    GW->>UA: 동일
+    UA->>DB: emailVerified = true
+    UA-->>SPA: { message }
+    SPA->>SPA: /customer/login 이동
+  end
+
+  rect rgb(245, 250, 240)
+    Note over User,UA: 2. 로그인 (JWT)
+    User->>SPA: 이메일/비밀번호 제출
+    SPA->>Nginx: POST /api/user/customer/login
+    Nginx->>GW: 동일
+    GW->>UA: 동일
+    UA->>DB: 비밀번호 검증
+    UA-->>SPA: JWT 문자열 (text/plain)
+    SPA->>SPA: AuthContext.login(token) → localStorage 저장
+    SPA->>SPA: 원래 가려던 경로 (location.state.from) 로 navigate
+  end
+
+  rect rgb(255, 250, 240)
+    Note over User,OA: 3. 상품 검색 / 상세
+    User->>SPA: 상품명 입력
+    SPA->>Nginx: GET /api/order/search/product?name=
+    Note right of SPA: axios interceptor<br/>Authorization: Bearer JWT
+    Nginx->>GW: GET /order/search/product
+    GW->>OA: GET /search/product
+    OA->>DB: 상품 검색
+    OA-->>SPA: ProductDto[]
+    SPA->>SPA: card-list 렌더링
+
+    User->>SPA: 상품 카드 클릭
+    SPA->>Nginx: GET /api/order/search/product/detail?productId=
+    Nginx->>GW: 동일
+    GW->>OA: 동일
+    OA-->>SPA: ProductDto (옵션 목록 포함)
+  end
+
+  rect rgb(255, 245, 245)
+    Note over User,OA: 4. 장바구니 담기
+    User->>SPA: 옵션별 수량 입력 → 담기
+    SPA->>Nginx: POST /api/order/customer/cart { AddProductCartForm }
+    Nginx->>GW: POST /order/customer/cart
+    GW->>OA: POST /customer/cart
+    OA->>DB: Redis 에 장바구니 upsert
+    OA-->>SPA: Cart
+    SPA->>SPA: queryClient.invalidateQueries(['cart'])<br/>/customer/cart 이동
+  end
+
+  rect rgb(250, 245, 255)
+    Note over User,OA: 5. 주문 (ADR-001 멱등성)
+    User->>SPA: 수량 조정 → 주문하기
+    SPA->>SPA: crypto.randomUUID() 로 Idempotency-Key 생성
+    SPA->>Nginx: POST /api/order/customer/cart/order<br/>Header: Idempotency-Key
+    Nginx->>GW: 동일
+    GW->>OA: 동일
+    OA->>DB: IdempotencyService.execute(key)
+    OA->>DB: Order 저장 (PENDING)
+    OA->>K: Kafka publish (ADR-003 SAGA: stock.reserve)
+    OA-->>SPA: { orderId, status: PENDING, ... }
+    SPA->>SPA: /customer/orders/:orderId 이동
+  end
+
+  rect rgb(240, 255, 240)
+    Note over User,OA: 6. 주문 상세 (SAGA 폴링)
+    loop status ∈ { PENDING, PAID } 동안 2초 간격
+      SPA->>Nginx: GET /api/order/customer/orders/:id
+      Nginx->>GW: 동일
+      GW->>OA: 동일
+      OA->>DB: Order 조회
+      OA-->>SPA: OrderDto
+    end
+    Note right of K: SAGA: stock.reserved → payment.charged<br/>→ CONFIRMED 또는 보상 → FAILED
+  end
+
+  rect rgb(255, 255, 235)
+    Note over User,UA: 7. 잔액 충전
+    User->>SPA: 금액/메모/출처 입력
+    SPA->>Nginx: POST /api/user/customer/balance
+    Nginx->>GW: 동일
+    GW->>UA: POST /customer/balance
+    UA->>DB: CustomerBalanceHistory 저장
+    UA-->>SPA: { balance }
+  end
+
+  Note over SPA: ⚠️ 토큰 만료 / 401 응답 시<br/>axios interceptor → localStorage 삭제 → /customer/login 강제 이동
+```
+
+---
+
+## 3. 화면 ↔ API 매핑
+
+| 화면 (route) | 컴포넌트 | 메서드 + 경로 | 가드 |
+|---|---|---|---|
+| `/customer/signup` | `Signup.tsx` | `POST /api/user/customer/signup` | 없음 |
+| `/customer/signup/verify` | `SignupVerify.tsx` | `PUT  /api/user/customer/signup/verify` | 없음 |
+| `/customer/login` | `Login.tsx` | `POST /api/user/customer/login` | 없음 |
+| `/customer/products` | `Products.tsx` | `GET  /api/order/search/product?name=` | CUSTOMER |
+| `/customer/products/:id` | `ProductDetail.tsx` | `GET  /api/order/search/product/detail` + `POST /api/order/customer/cart` | CUSTOMER |
+| `/customer/cart` | `Cart.tsx` | `GET/PUT /api/order/customer/cart` + `POST /api/order/customer/cart/order` (`Idempotency-Key`) | CUSTOMER |
+| `/customer/orders` | `Orders.tsx` | (입력 폼만, 백엔드 호출 없음) | CUSTOMER |
+| `/customer/orders/:orderId` | `OrderDetail.tsx` | `GET  /api/order/customer/orders/:id` (PENDING/PAID 동안 2 s 폴링) | CUSTOMER |
+| `/customer/balance` | `Balance.tsx` | `POST /api/user/customer/balance` | CUSTOMER |
+
+---
+
+## 4. 관련 ADR
+
+- **ADR-001**: 멱등성 키로 결제·주문 중복 방지. SPA 가 `crypto.randomUUID()` 로 키를 만들어 `POST /customer/cart/order` 헤더에 실음.
+- **ADR-003**: Choreography SAGA. 주문 생성 직후 응답은 PENDING; SPA 가 `OrderDetail` 에서 2 초 폴링으로 CONFIRMED/FAILED 까지 추적.
+- **ADR-005**: Eureka + gateway lb 라우팅. SPA → nginx → gateway → `lb://user-api` / `lb://order-api`.
+
+## 5. 알려진 한계
+
+- `ProductDto` 에 `sellerId` 가 없어 `AddProductCartForm.sellerId` 를 임시로 `0` 전송 (백엔드 응답 보완 후 정정 필요).
+- 백엔드에 주문 목록 API 가 없어 `/customer/orders` 는 ID 입력 폼만 제공.
+- SELLER 화면 미구현 (별도 PR).

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,6 +39,9 @@ importers:
         specifier: ^4.4.3
         version: 4.4.3
     devDependencies:
+      '@types/node':
+        specifier: ^25.9.1
+        version: 25.9.1
       '@types/react':
         specifier: ^18.3.12
         version: 18.3.29
@@ -53,7 +56,7 @@ importers:
         version: 8.60.0(eslint@8.57.1)(typescript@5.9.3)
       '@vitejs/plugin-react':
         specifier: ^4.3.3
-        version: 4.7.0(vite@5.4.21)
+        version: 4.7.0(vite@5.4.21(@types/node@25.9.1))
       eslint:
         specifier: ^8.57.1
         version: 8.57.1
@@ -68,7 +71,7 @@ importers:
         version: 5.9.3
       vite:
         specifier: ^5.4.10
-        version: 5.4.21
+        version: 5.4.21(@types/node@25.9.1)
 
 packages:
 
@@ -557,6 +560,9 @@ packages:
 
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+
+  '@types/node@25.9.1':
+    resolution: {integrity: sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==}
 
   '@types/prop-types@15.7.15':
     resolution: {integrity: sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==}
@@ -1245,6 +1251,9 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
+  undici-types@7.24.6:
+    resolution: {integrity: sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==}
+
   update-browserslist-db@1.2.3:
     resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
     hasBin: true
@@ -1690,6 +1699,10 @@ snapshots:
 
   '@types/estree@1.0.8': {}
 
+  '@types/node@25.9.1':
+    dependencies:
+      undici-types: 7.24.6
+
   '@types/prop-types@15.7.15': {}
 
   '@types/react-dom@18.3.7(@types/react@18.3.29)':
@@ -1794,7 +1807,7 @@ snapshots:
 
   '@ungap/structured-clone@1.3.1': {}
 
-  '@vitejs/plugin-react@4.7.0(vite@5.4.21)':
+  '@vitejs/plugin-react@4.7.0(vite@5.4.21(@types/node@25.9.1))':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/plugin-transform-react-jsx-self': 7.29.7(@babel/core@7.29.7)
@@ -1802,7 +1815,7 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-beta.27
       '@types/babel__core': 7.20.5
       react-refresh: 0.17.0
-      vite: 5.4.21
+      vite: 5.4.21(@types/node@25.9.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -2420,6 +2433,8 @@ snapshots:
 
   typescript@5.9.3: {}
 
+  undici-types@7.24.6: {}
+
   update-browserslist-db@1.2.3(browserslist@4.28.2):
     dependencies:
       browserslist: 4.28.2
@@ -2430,12 +2445,13 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
-  vite@5.4.21:
+  vite@5.4.21(@types/node@25.9.1):
     dependencies:
       esbuild: 0.21.5
       postcss: 8.5.15
       rollup: 4.60.4
     optionalDependencies:
+      '@types/node': 25.9.1
       fsevents: 2.3.3
 
   which@2.0.2:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,15 +14,30 @@ importers:
 
   apps/web:
     dependencies:
+      '@hookform/resolvers':
+        specifier: ^5.4.0
+        version: 5.4.0(react-hook-form@7.76.1(react@18.3.1))
+      '@tanstack/react-query':
+        specifier: ^5.100.14
+        version: 5.100.14(react@18.3.1)
+      axios:
+        specifier: ^1.16.1
+        version: 1.16.1
       react:
         specifier: ^18.3.1
         version: 18.3.1
       react-dom:
         specifier: ^18.3.1
         version: 18.3.1(react@18.3.1)
+      react-hook-form:
+        specifier: ^7.76.1
+        version: 7.76.1(react@18.3.1)
       react-router-dom:
         specifier: ^6.27.0
         version: 6.30.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      zod:
+        specifier: ^4.4.3
+        version: 4.4.3
     devDependencies:
       '@types/react':
         specifier: ^18.3.12
@@ -296,6 +311,11 @@ packages:
     resolution: {integrity: sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
 
+  '@hookform/resolvers@5.4.0':
+    resolution: {integrity: sha512-EIsqr/t/qbinPIhGjMdtvutIN1Kk4uwbROE9/UQ93CAVGR7GkA7Y92+fX80OzXi/OB67jVFYwKGO1WzkxmkFZw==}
+    peerDependencies:
+      react-hook-form: ^7.55.0
+
   '@humanwhocodes/config-array@0.13.0':
     resolution: {integrity: sha512-DZLEEqFWQFiyK6h5YIeynKx7JlvCYWL0cImfSRXZ9l4Sg2efkFGTuFf6vzXjK1cq6IYkU+Eg/JizXw+TD2vRNw==}
     engines: {node: '>=10.10.0'}
@@ -378,66 +398,79 @@ packages:
     resolution: {integrity: sha512-EIPRXTVQpHyF8WOo219AD2yEltPehLTcTMz2fn6JsatLYSzQf00hj3rulF+yauOlF9/FtM2WpkT/hJh/KJFGhA==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.60.4':
     resolution: {integrity: sha512-J3Yh9PzzF1Ovah2At+lHiGQdsYgArxBbXv/zHfSyaiFQEqvNv7DcW98pCrmdjCZBrqBiKrKKe2V+aaSGWuBe/w==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.60.4':
     resolution: {integrity: sha512-BFDEZMYfUvLn37ONE1yMBojPxnMlTFsdyNoqncT0qFq1mAfllL+ATMMJd8TeuVMiX84s1KbcxcZbXInmcO2mRg==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.60.4':
     resolution: {integrity: sha512-pc9EYOSlOgdQ2uPl1o9PF6/kLSgaUosia7gOuS8mB69IxJvlclko1MECXysjs5ryez1/5zjYqx3+xYU0TU6R1A==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.60.4':
     resolution: {integrity: sha512-NxnomyxYerDh5n4iLrNa+sH+Z+U4BMEE46V2PgQ/hoB909i8gV1M5wPojWg9fk1jWpO3IQnOs20K4wyZuFLEFQ==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.60.4':
     resolution: {integrity: sha512-nbJnQ8a3z1mtmrwImCYhc6BGpThAyYVRQxw9uKSKG4wR6aAYno9sVjJ0zaZcW9BPJX1GbrDPf+SvdWjgTuDmnw==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.60.4':
     resolution: {integrity: sha512-2EU6acNrQLd8tYvo/LXW535wupT3m6fo7HKo6lr7ktQoItxTyOL1ZCR/GfGCuXl2vR+zmfI6eRXkSemafv+iVg==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.60.4':
     resolution: {integrity: sha512-WeBtoMuaMxiiIrO2IYP3xs6GMWkJP2C0EoT8beTLkUPmzV1i/UcOSVw1d5r9KBODtHKilG5yFxsGRnBbK3wJ4A==}
     cpu: [ppc64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.60.4':
     resolution: {integrity: sha512-FJHFfqpKUI3A10WrWKiFbBZ7yVbGT4q4B5o1qKFFojqpaYoh9LrQgqWCmmcxQzVSXYtyB5bzkXrYzlHTs21MYA==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.60.4':
     resolution: {integrity: sha512-mcEl6CUT5IAUmQf1m9FYSmVqCJlpQ8r8eyftFUHG8i9OhY7BkBXSUdnLH5DOf0wCOjcP9v/QO93zpmF1SptCCw==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.60.4':
     resolution: {integrity: sha512-ynt3JxVd2w2buzoKDWIyiV1pJW93xlQic1THVLXilz429oijRpSHivZAgp65KBu+cMcgf1eVVjdnTLvPxgCuoQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.60.4':
     resolution: {integrity: sha512-Boiz5+MsaROEWDf+GGEwF8VMHGhlUoQMtIPjOgA5fv4osupqTVnJteQNKJwUcnUog2G55jYXH7KZFFiJe0TEzQ==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.60.4':
     resolution: {integrity: sha512-+qfSY27qIrFfI/Hom04KYFw3GKZSGU4lXus51wsb5EuySfFlWRwjkKWoE9emgRw/ukoT4Udsj4W/+xxG8VbPKg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.60.4':
     resolution: {integrity: sha512-VpTfOPHgVXEBeeR8hZ2O0F3aSso+JDWqTWmTmzcQKted54IAdUVbxE+j/MVxUsKa8L20HJhv3vUezVPoquqWjA==}
@@ -468,6 +501,17 @@ packages:
     resolution: {integrity: sha512-QVTUovf40zgTqlFVrKA1uXMVvU2QWEFWfAH8Wdc48IxLvrJMQVMBRjuQyUpzZCDkakImib9eVazbWlC6ksWtJw==}
     cpu: [x64]
     os: [win32]
+
+  '@standard-schema/utils@0.3.0':
+    resolution: {integrity: sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==}
+
+  '@tanstack/query-core@5.100.14':
+    resolution: {integrity: sha512-5X41dGpxgeaHISCRW2oYwcSycZeULZzAunaudXT9ov1KOTj9xwt0CH6hbwqP1/z74ZWF7rYFnDpyYH07XFcZew==}
+
+  '@tanstack/react-query@5.100.14':
+    resolution: {integrity: sha512-oOr6aRdSFEwWhzxEkD/9ZcItM3+LjBSkeVmadWKwUssAHTsqd/7bOjWrX4AbvEkoEhgAxzN0Xk6H/aYzXiYBAw==}
+    peerDependencies:
+      react: ^18 || ^19
 
   '@turbo/darwin-64@2.9.15':
     resolution: {integrity: sha512-nnDo9R1Df+s2x6jxlERtbg7xRpuicf8p4J2krcnjeaMBt3q9V41pGXa4t9YM2Y4ozozsVJ+CH405CJUrWIQK4Q==}
@@ -603,6 +647,10 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
+  agent-base@6.0.2:
+    resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
+    engines: {node: '>= 6.0.0'}
+
   ajv@6.15.0:
     resolution: {integrity: sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==}
 
@@ -616,6 +664,12 @@ packages:
 
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
+
+  asynckit@0.4.0:
+    resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
+
+  axios@1.16.1:
+    resolution: {integrity: sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A==}
 
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
@@ -641,6 +695,10 @@ packages:
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
 
+  call-bind-apply-helpers@1.0.2:
+    resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
+    engines: {node: '>= 0.4'}
+
   callsites@3.1.0:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
     engines: {node: '>=6'}
@@ -658,6 +716,10 @@ packages:
 
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+
+  combined-stream@1.0.8:
+    resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
+    engines: {node: '>= 0.8'}
 
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
@@ -684,12 +746,36 @@ packages:
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
 
+  delayed-stream@1.0.0:
+    resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
+    engines: {node: '>=0.4.0'}
+
   doctrine@3.0.0:
     resolution: {integrity: sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==}
     engines: {node: '>=6.0.0'}
 
+  dunder-proto@1.0.1:
+    resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
+    engines: {node: '>= 0.4'}
+
   electron-to-chromium@1.5.362:
     resolution: {integrity: sha512-PUY2DrLvkjkUuWqq+KPL2iWshrJsZOcIojzRQ7eXFacc9dWga7MGMJAa15VbiejSZB1PAXaRLAiKgruHP8LB1w==}
+
+  es-define-property@1.0.1:
+    resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
+    engines: {node: '>= 0.4'}
+
+  es-errors@1.3.0:
+    resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
+    engines: {node: '>= 0.4'}
+
+  es-object-atoms@1.1.2:
+    resolution: {integrity: sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==}
+    engines: {node: '>= 0.4'}
+
+  es-set-tostringtag@2.1.0:
+    resolution: {integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==}
+    engines: {node: '>= 0.4'}
 
   esbuild@0.21.5:
     resolution: {integrity: sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==}
@@ -789,6 +875,19 @@ packages:
   flatted@3.4.2:
     resolution: {integrity: sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==}
 
+  follow-redirects@1.16.0:
+    resolution: {integrity: sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==}
+    engines: {node: '>=4.0'}
+    peerDependencies:
+      debug: '*'
+    peerDependenciesMeta:
+      debug:
+        optional: true
+
+  form-data@4.0.5:
+    resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
+    engines: {node: '>= 6'}
+
   fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
 
@@ -797,9 +896,20 @@ packages:
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
 
+  function-bind@1.1.2:
+    resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
+
   gensync@1.0.0-beta.2:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
     engines: {node: '>=6.9.0'}
+
+  get-intrinsic@1.3.0:
+    resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
+    engines: {node: '>= 0.4'}
+
+  get-proto@1.0.1:
+    resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
+    engines: {node: '>= 0.4'}
 
   glob-parent@6.0.2:
     resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
@@ -813,12 +923,32 @@ packages:
     resolution: {integrity: sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==}
     engines: {node: '>=8'}
 
+  gopd@1.2.0:
+    resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
+    engines: {node: '>= 0.4'}
+
   graphemer@1.4.0:
     resolution: {integrity: sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==}
 
   has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
+
+  has-symbols@1.1.0:
+    resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
+    engines: {node: '>= 0.4'}
+
+  has-tostringtag@1.0.2:
+    resolution: {integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==}
+    engines: {node: '>= 0.4'}
+
+  hasown@2.0.3:
+    resolution: {integrity: sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==}
+    engines: {node: '>= 0.4'}
+
+  https-proxy-agent@5.0.1:
+    resolution: {integrity: sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==}
+    engines: {node: '>= 6'}
 
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
@@ -905,6 +1035,18 @@ packages:
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
+  math-intrinsics@1.1.0:
+    resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
+    engines: {node: '>= 0.4'}
+
+  mime-db@1.52.0:
+    resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
+    engines: {node: '>= 0.6'}
+
+  mime-types@2.1.35:
+    resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
+    engines: {node: '>= 0.6'}
+
   minimatch@10.2.5:
     resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
     engines: {node: 18 || 20 || >=22}
@@ -973,6 +1115,10 @@ packages:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
 
+  proxy-from-env@2.1.0:
+    resolution: {integrity: sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==}
+    engines: {node: '>=10'}
+
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
@@ -984,6 +1130,12 @@ packages:
     resolution: {integrity: sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==}
     peerDependencies:
       react: ^18.3.1
+
+  react-hook-form@7.76.1:
+    resolution: {integrity: sha512-rYM7tPiWlu3nZchkR/ex7piyzui2vFPyaLnXnI/RnblB/L4qfMmyses8llJVtF1NpE9WBBsJlGtcSZzPCXW1qQ==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      react: ^16.8.0 || ^17 || ^18 || ^19
 
   react-refresh@0.17.0:
     resolution: {integrity: sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==}
@@ -1151,6 +1303,9 @@ packages:
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
+
+  zod@4.4.3:
+    resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
 
 snapshots:
 
@@ -1358,6 +1513,11 @@ snapshots:
 
   '@eslint/js@8.57.1': {}
 
+  '@hookform/resolvers@5.4.0(react-hook-form@7.76.1(react@18.3.1))':
+    dependencies:
+      '@standard-schema/utils': 0.3.0
+      react-hook-form: 7.76.1(react@18.3.1)
+
   '@humanwhocodes/config-array@0.13.0':
     dependencies:
       '@humanwhocodes/object-schema': 2.0.3
@@ -1479,6 +1639,15 @@ snapshots:
 
   '@rollup/rollup-win32-x64-msvc@4.60.4':
     optional: true
+
+  '@standard-schema/utils@0.3.0': {}
+
+  '@tanstack/query-core@5.100.14': {}
+
+  '@tanstack/react-query@5.100.14(react@18.3.1)':
+    dependencies:
+      '@tanstack/query-core': 5.100.14
+      react: 18.3.1
 
   '@turbo/darwin-64@2.9.15':
     optional: true
@@ -1643,6 +1812,12 @@ snapshots:
 
   acorn@8.16.0: {}
 
+  agent-base@6.0.2:
+    dependencies:
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
   ajv@6.15.0:
     dependencies:
       fast-deep-equal: 3.1.3
@@ -1657,6 +1832,18 @@ snapshots:
       color-convert: 2.0.1
 
   argparse@2.0.1: {}
+
+  asynckit@0.4.0: {}
+
+  axios@1.16.1:
+    dependencies:
+      follow-redirects: 1.16.0
+      form-data: 4.0.5
+      https-proxy-agent: 5.0.1
+      proxy-from-env: 2.1.0
+    transitivePeerDependencies:
+      - debug
+      - supports-color
 
   balanced-match@1.0.2: {}
 
@@ -1681,6 +1868,11 @@ snapshots:
       node-releases: 2.0.46
       update-browserslist-db: 1.2.3(browserslist@4.28.2)
 
+  call-bind-apply-helpers@1.0.2:
+    dependencies:
+      es-errors: 1.3.0
+      function-bind: 1.1.2
+
   callsites@3.1.0: {}
 
   caniuse-lite@1.0.30001793: {}
@@ -1695,6 +1887,10 @@ snapshots:
       color-name: 1.1.4
 
   color-name@1.1.4: {}
+
+  combined-stream@1.0.8:
+    dependencies:
+      delayed-stream: 1.0.0
 
   concat-map@0.0.1: {}
 
@@ -1714,11 +1910,34 @@ snapshots:
 
   deep-is@0.1.4: {}
 
+  delayed-stream@1.0.0: {}
+
   doctrine@3.0.0:
     dependencies:
       esutils: 2.0.3
 
+  dunder-proto@1.0.1:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-errors: 1.3.0
+      gopd: 1.2.0
+
   electron-to-chromium@1.5.362: {}
+
+  es-define-property@1.0.1: {}
+
+  es-errors@1.3.0: {}
+
+  es-object-atoms@1.1.2:
+    dependencies:
+      es-errors: 1.3.0
+
+  es-set-tostringtag@2.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      has-tostringtag: 1.0.2
+      hasown: 2.0.3
 
   esbuild@0.21.5:
     optionalDependencies:
@@ -1859,12 +2078,42 @@ snapshots:
 
   flatted@3.4.2: {}
 
+  follow-redirects@1.16.0: {}
+
+  form-data@4.0.5:
+    dependencies:
+      asynckit: 0.4.0
+      combined-stream: 1.0.8
+      es-set-tostringtag: 2.1.0
+      hasown: 2.0.3
+      mime-types: 2.1.35
+
   fs.realpath@1.0.0: {}
 
   fsevents@2.3.3:
     optional: true
 
+  function-bind@1.1.2: {}
+
   gensync@1.0.0-beta.2: {}
+
+  get-intrinsic@1.3.0:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.2
+      function-bind: 1.1.2
+      get-proto: 1.0.1
+      gopd: 1.2.0
+      has-symbols: 1.1.0
+      hasown: 2.0.3
+      math-intrinsics: 1.1.0
+
+  get-proto@1.0.1:
+    dependencies:
+      dunder-proto: 1.0.1
+      es-object-atoms: 1.1.2
 
   glob-parent@6.0.2:
     dependencies:
@@ -1883,9 +2132,28 @@ snapshots:
     dependencies:
       type-fest: 0.20.2
 
+  gopd@1.2.0: {}
+
   graphemer@1.4.0: {}
 
   has-flag@4.0.0: {}
+
+  has-symbols@1.1.0: {}
+
+  has-tostringtag@1.0.2:
+    dependencies:
+      has-symbols: 1.1.0
+
+  hasown@2.0.3:
+    dependencies:
+      function-bind: 1.1.2
+
+  https-proxy-agent@5.0.1:
+    dependencies:
+      agent-base: 6.0.2
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
 
   ignore@5.3.2: {}
 
@@ -1954,6 +2222,14 @@ snapshots:
     dependencies:
       yallist: 3.1.1
 
+  math-intrinsics@1.1.0: {}
+
+  mime-db@1.52.0: {}
+
+  mime-types@2.1.35:
+    dependencies:
+      mime-db: 1.52.0
+
   minimatch@10.2.5:
     dependencies:
       brace-expansion: 5.0.6
@@ -2013,6 +2289,8 @@ snapshots:
 
   prelude-ls@1.2.1: {}
 
+  proxy-from-env@2.1.0: {}
+
   punycode@2.3.1: {}
 
   queue-microtask@1.2.3: {}
@@ -2022,6 +2300,10 @@ snapshots:
       loose-envify: 1.4.0
       react: 18.3.1
       scheduler: 0.23.2
+
+  react-hook-form@7.76.1(react@18.3.1):
+    dependencies:
+      react: 18.3.1
 
   react-refresh@0.17.0: {}
 
@@ -2167,3 +2449,5 @@ snapshots:
   yallist@3.1.1: {}
 
   yocto-queue@0.1.0: {}
+
+  zod@4.4.3: {}


### PR DESCRIPTION
## 관련 이슈
Closes #43

## 변경 유형
- [x] ✨ Feature

## 요약
`apps/web` (Vite+React+TS SPA) 와 백엔드 **CUSTOMER flow** 전체 연동.
인증 / 상품 검색·상세 / 장바구니 / 주문 / 잔액 충전. SELLER 화면은 별도 PR.

## 영향 받는 모듈
- [ ] userApi
- [ ] orderApi
- [ ] gateway
- [ ] infra
- [x] **신규/수정** `apps/web` (CUSTOMER flow + API/Auth 인프라)

## 동작 확인
**로컬 (Vite dev + proxy)**
```
pnpm install
pnpm dev   # http://localhost:5173
```

**Docker 통합 환경**
```
docker compose -f docker-compose.test.yml up --build
# http://localhost:5173 → nginx → /api/* → gateway:80 → user-api / order-api
```

- `pnpm typecheck` 통과 (TS strict)
- 시나리오: 회원가입 → 이메일 인증 → 로그인 → 상품 검색 → 상세에서 옵션 수량 선택 → 장바구니 → 주문(Idempotency-Key) → 주문 상세 폴링(SAGA PENDING→CONFIRMED)
- 401 응답 시 인터셉터가 `/customer/login` 리다이렉트, 토큰은 `localStorage`

## 라이브러리 (이번 PR 추가)
- `axios` — interceptor 로 JWT 자동 주입, 401 핸들링
- `@tanstack/react-query` — 서버 상태 캐싱, 폴링 (`refetchInterval`)
- `react-hook-form` + `@hookform/resolvers` + `zod` — 폼/검증
- `@types/node` — vite.config.ts 의 `node:path`

## 백엔드 API 매핑 (gateway 라우팅: `/api/user/*` → user-api, `/api/order/*` → order-api)
| 화면 | 메서드 + 경로 |
|---|---|
| Signup | POST `/api/user/customer/signup` |
| Verify | PUT  `/api/user/customer/signup/verify?email=&code=` |
| Login | POST `/api/user/customer/login` (응답: JWT 문자열) |
| Products (검색) | GET `/api/order/search/product?name=` |
| ProductDetail | GET `/api/order/search/product/detail?productId=` |
| Cart | GET/POST/PUT `/api/order/customer/cart` |
| Order | POST `/api/order/customer/cart/order` (Idempotency-Key) |
| OrderDetail | GET `/api/order/customer/orders/{orderId}` |
| Balance | POST `/api/user/customer/balance` |

## 체크리스트
- [x] 단위 / 통합 테스트 통과 (`./gradlew test`) — **해당 없음** (Java 모듈 미변경)
- [x] DB 스키마 변경이 있다면 Flyway 마이그레이션 추가 — **해당 없음**
- [x] 두 모듈에 공유되는 DTO/Authority 등 변경 시 양쪽 반영 — **해당 없음** (FE 만 백엔드 DTO 미러)
- [x] 운영 yaml 추가 설정 시 application-test.yml / docker-compose.test.yml 반영 — **해당 없음**
- [x] 외부 API 추가/변경 시 Swagger 갱신 — **해당 없음** (FE 만 변경, API 미변경)

## 알려진 한계 / 후속
- **`ProductDto` 에 `sellerId` 미포함** — Cart 추가 시 임시로 0 전송. 백엔드 응답 보완 후 정정 필요 (별도 이슈로 가능).
- **주문 목록 API 부재** — `/customer/orders/{orderId}` 만 있어 Orders 화면은 ID 입력 폼으로 처리.
- **SELLER 화면 미구현** — 스캐폴드 placeholder 유지. 다음 PR.
- **CI**: `.github/workflows/CICD.yml` 에 Node lint/build 잡 미추가 (별도 PR 예정).