### PR TITLE
fix(infra): Docker Hub deprecated 이미지 교체 (openjdk:17, bitnami:3.7)

### DIFF
--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -52,7 +52,7 @@ services:
   # ADR-003: Choreography SAGA 의 이벤트 브로커.
   # KRaft 모드(zookeeper 없이) 단일 노드. 토픽은 producer 발행 시 자동 생성.
   kafka:
-    image: bitnami/kafka:3.7
+    image: bitnamilegacy/kafka:3.7  # bitnami 가 namespace 를 옮겨 기존 태그는 docker.io 에서 사라짐
     container_name: commerce-kafka-test
     ports:
       - "9092:9092"

--- a/eurekaServer/Dockerfile
+++ b/eurekaServer/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:17
+FROM eclipse-temurin:17-jre
 RUN mkdir -p deploy
 WORKDIR /deploy
 COPY ./build/libs/eurekaServer-0.1.jar eureka-server.jar

--- a/gateway/Dockerfile
+++ b/gateway/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:17
+FROM eclipse-temurin:17-jre
 RUN mkdir -p deploy
 WORKDIR /deploy
 COPY ./build/libs/gateway-0.1.jar gateway.jar

--- a/orderApi/Dockerfile
+++ b/orderApi/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:17
+FROM eclipse-temurin:17-jre
 RUN mkdir -p deploy
 WORKDIR /deploy
 COPY ./build/libs/orderApi-0.1.jar orderApi.jar

--- a/userApi/Dockerfile
+++ b/userApi/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:17
+FROM eclipse-temurin:17-jre
 RUN mkdir -p deploy
 WORKDIR /deploy
 COPY ./build/libs/userApi-0.1.jar userApi.jar


### PR DESCRIPTION
@
## 관련 이슈
Closes #48

## 변경 유형
- [x] 🐞 Bug fix
- [ ] ✨ Feature
- [ ] 🛠 Refactor / Chore
- [ ] 🗄 DB 마이그레이션 (Flyway V_*.sql 추가)
- [ ] 📝 Docs

## 요약
Docker Hub 에서 `openjdk` 공식 이미지가 폐기되고 `bitnami/*` 가 `bitnamilegacy/*` 네임스페이스로 이전되어 `docker compose up` 자체가 막혀 있던 상태를 정상화한다. 이 변경 없이는 로컬/CI 통합 테스트 환경 기동이 불가능하므로 main 으로 우선 분리 머지한다.

## 영향 받는 모듈
- [x] userApi (Dockerfile)
- [x] orderApi (Dockerfile)
- [x] gateway (Dockerfile)
- [x] infra (docker-compose.test.yml, eurekaServer/Dockerfile)

## 동작 확인
- `docker compose -f docker-compose.test.yml build` 정상 완료
- `docker compose -f docker-compose.test.yml up` 으로 userApi / orderApi / gateway / eurekaServer / kafka 정상 기동 확인 (release/qa-adr-005-scenario-3 브랜치 QA 측정 과정에서 동일 변경으로 검증됨)
- 변경 내용:
  - `openjdk:17` → `eclipse-temurin:17-jre`
  - `bitnami/kafka:3.7` → `bitnamilegacy/kafka:3.7`

## 체크리스트
- [x] 단위 / 통합 테스트 통과 (`./gradlew test`) — 인프라 이미지 교체만으로 JVM/Spring 동작에는 영향 없음. CI 에서 재확인.
- [x] DB 스키마 변경이 있다면 Flyway 마이그레이션 (`V_*.sql`) 추가 — 해당 없음
- [x] 두 모듈에 공유되는 DTO/Authority 등 변경 시 양쪽 모두 반영 — 해당 없음
- [x] 운영 yaml(`application.yml`)에 추가된 설정이 있다면 `application-test.yml` 및 `docker-compose.test.yml`에도 반영 — yaml 설정 변경 없음 (이미지 태그만 교체)
- [x] 외부 API 추가/변경 시 Swagger 문서 갱신 — 해당 없음

## 스크린샷 / 로그 (선택)
원 commit: `318198d` (release/qa-adr-005-scenario-3 에서 분리). QA 브랜치에서는 동일 변경이 rebase 로 제거되며 본 PR 머지 후 main 동기화 시점에 자연스럽게 반영된다.
@