### PR TITLE
feat(web): SELLER flow 화면 구현 + 흐름도 문서

### DIFF
--- a/apps/web/src/router.tsx
+++ b/apps/web/src/router.tsx
@@ -12,7 +12,13 @@ import { CustomerSignup } from './routes/customer/Signup'
 import { CustomerSignupVerify } from './routes/customer/SignupVerify'
 import { ProtectedRoute } from './shared/auth/ProtectedRoute'
 import { SellerLayout } from './routes/seller/Layout'
+import { SellerHome } from './routes/seller/Home'
+import { SellerLogin } from './routes/seller/Login'
+import { SellerSignup } from './routes/seller/Signup'
+import { SellerSignupVerify } from './routes/seller/SignupVerify'
 import { SellerProducts } from './routes/seller/Products'
+import { SellerProductNew } from './routes/seller/ProductNew'
+import { SellerProductEdit } from './routes/seller/ProductEdit'
 import { SellerOrders } from './routes/seller/Orders'
 
 export const router = createBrowserRouter([
@@ -79,9 +85,42 @@ export const router = createBrowserRouter([
     path: '/seller',
     element: <SellerLayout />,
     children: [
-      { index: true, element: <Navigate to="products" replace /> },
-      { path: 'products', element: <SellerProducts /> },
-      { path: 'orders', element: <SellerOrders /> },
+      { index: true, element: <SellerHome /> },
+      { path: 'login', element: <SellerLogin /> },
+      { path: 'signup', element: <SellerSignup /> },
+      { path: 'signup/verify', element: <SellerSignupVerify /> },
+      {
+        path: 'products',
+        element: (
+          <ProtectedRoute role="SELLER" loginPath="/seller/login">
+            <SellerProducts />
+          </ProtectedRoute>
+        ),
+      },
+      {
+        path: 'products/new',
+        element: (
+          <ProtectedRoute role="SELLER" loginPath="/seller/login">
+            <SellerProductNew />
+          </ProtectedRoute>
+        ),
+      },
+      {
+        path: 'products/:id/edit',
+        element: (
+          <ProtectedRoute role="SELLER" loginPath="/seller/login">
+            <SellerProductEdit />
+          </ProtectedRoute>
+        ),
+      },
+      {
+        path: 'orders',
+        element: (
+          <ProtectedRoute role="SELLER" loginPath="/seller/login">
+            <SellerOrders />
+          </ProtectedRoute>
+        ),
+      },
     ],
   },
 ])

--- a/apps/web/src/routes/seller/Home.tsx
+++ b/apps/web/src/routes/seller/Home.tsx
@@ -1,0 +1,24 @@
+import { Link } from 'react-router-dom'
+import { useAuth } from '@/shared/auth/AuthContext'
+
+export function SellerHome() {
+  const { user } = useAuth()
+  return (
+    <section>
+      <h1>판매자 홈</h1>
+      {user ? (
+        <p>
+          <strong>{user.email}</strong> 님 환영합니다.{' '}
+          <Link to="/seller/products">상품 관리로 가기 →</Link>
+        </p>
+      ) : (
+        <p>
+          <Link to="/seller/signup">회원가입</Link>
+          {' / '}
+          <Link to="/seller/login">로그인</Link>
+          {' 후 이용하세요.'}
+        </p>
+      )}
+    </section>
+  )
+}

--- a/apps/web/src/routes/seller/Layout.tsx
+++ b/apps/web/src/routes/seller/Layout.tsx
@@ -1,15 +1,38 @@
-import { Link, Outlet } from 'react-router-dom'
+import { Link, Outlet, useLocation, useNavigate } from 'react-router-dom'
+import { useAuth } from '@/shared/auth/AuthContext'
 
 export function SellerLayout() {
+  const { user, logout } = useAuth()
+  const navigate = useNavigate()
+  const location = useLocation()
+
+  const onLogout = () => {
+    logout()
+    navigate('/seller/login')
+  }
+
+  const onAuthPage = location.pathname.includes('/login') || location.pathname.includes('/signup')
+
   return (
     <div>
       <header>
         <nav>
+          <Link to="/seller">홈</Link>
+          {' | '}
           <Link to="/seller/products">상품 관리</Link>
           {' | '}
           <Link to="/seller/orders">주문 관리</Link>
           {' | '}
           <Link to="/customer">← CUSTOMER 모드</Link>
+          <span style={{ float: 'right' }}>
+            {user ? (
+              <>
+                <span>{user.email}</span> <button type="button" onClick={onLogout}>로그아웃</button>
+              </>
+            ) : onAuthPage ? null : (
+              <Link to="/seller/login">로그인</Link>
+            )}
+          </span>
         </nav>
       </header>
       <main>

--- a/apps/web/src/routes/seller/Login.tsx
+++ b/apps/web/src/routes/seller/Login.tsx
@@ -1,0 +1,60 @@
+import { useForm } from 'react-hook-form'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { z } from 'zod'
+import { useMutation } from '@tanstack/react-query'
+import { Link, useLocation, useNavigate } from 'react-router-dom'
+import { loginSeller } from '@/shared/api/seller'
+import { extractApiMessage } from '@/shared/api/client'
+import { useAuth } from '@/shared/auth/AuthContext'
+
+const schema = z.object({
+  email: z.email('올바른 이메일을 입력하세요'),
+  password: z.string().min(1, '비밀번호를 입력하세요'),
+})
+type FormData = z.infer<typeof schema>
+
+export function SellerLogin() {
+  const { login } = useAuth()
+  const navigate = useNavigate()
+  const location = useLocation()
+  const from = (location.state as { from?: string } | null)?.from ?? '/seller'
+
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<FormData>({ resolver: zodResolver(schema) })
+
+  const loginMutation = useMutation({
+    mutationFn: loginSeller,
+    onSuccess: (token) => {
+      login(token)
+      navigate(from, { replace: true })
+    },
+  })
+
+  return (
+    <section>
+      <h1>로그인 (SELLER)</h1>
+      <form onSubmit={handleSubmit((data) => loginMutation.mutate(data))} className="form">
+        <label>
+          이메일
+          <input type="email" autoComplete="email" {...register('email')} />
+          {errors.email && <small className="err">{errors.email.message}</small>}
+        </label>
+        <label>
+          비밀번호
+          <input type="password" autoComplete="current-password" {...register('password')} />
+          {errors.password && <small className="err">{errors.password.message}</small>}
+        </label>
+        <button type="submit" disabled={loginMutation.isPending}>
+          {loginMutation.isPending ? '로그인 중...' : '로그인'}
+        </button>
+        {loginMutation.isError && <p className="err">{extractApiMessage(loginMutation.error)}</p>}
+      </form>
+      <p>
+        계정이 없나요? <Link to="/seller/signup">회원가입</Link>
+      </p>
+    </section>
+  )
+}

--- a/apps/web/src/routes/seller/Orders.tsx
+++ b/apps/web/src/routes/seller/Orders.tsx
@@ -1,8 +1,21 @@
+import { Link } from 'react-router-dom'
+
 export function SellerOrders() {
   return (
     <section>
       <h1>판매자 주문 관리</h1>
-      <p>GET /api/seller/orders 연동 예정.</p>
+      <p className="muted">
+        ⚠️ 백엔드에 SELLER 전용 주문 조회 API (<code>GET /seller/orders</code>) 가 아직
+        없어, 이 화면은 placeholder 입니다.
+      </p>
+      <p className="muted">
+        현재는 CUSTOMER 가 주문 후{' '}
+        <Link to="/customer/orders">CUSTOMER 모드 주문 상세</Link>
+        에서 상태(PENDING/PAID/CONFIRMED/FAILED) 를 확인할 수 있습니다.
+        <br />
+        SELLER 측 주문 흐름은 <code>docs/seller-flow.md</code> §6 의 알려진 한계를
+        참고하세요.
+      </p>
     </section>
   )
 }

--- a/apps/web/src/routes/seller/ProductEdit.tsx
+++ b/apps/web/src/routes/seller/ProductEdit.tsx
@@ -1,0 +1,235 @@
+import { useEffect, useState } from 'react'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { useNavigate, useParams } from 'react-router-dom'
+import { getProductDetail } from '@/shared/api/search'
+import {
+  addProductItem,
+  deleteProductItem,
+  updateProduct,
+  updateProductItem,
+} from '@/shared/api/seller'
+import { extractApiMessage } from '@/shared/api/client'
+
+interface ItemDraft {
+  id: number | null // null = 신규
+  name: string
+  price: number
+  count: number
+}
+
+export function SellerProductEdit() {
+  const { id } = useParams<{ id: string }>()
+  const productId = Number(id)
+  const navigate = useNavigate()
+  const queryClient = useQueryClient()
+
+  const detailQuery = useQuery({
+    queryKey: ['product', productId],
+    queryFn: () => getProductDetail(productId),
+    enabled: Number.isFinite(productId) && productId > 0,
+  })
+
+  const [name, setName] = useState('')
+  const [description, setDescription] = useState('')
+  const [items, setItems] = useState<ItemDraft[]>([])
+
+  // 처음 로드시 폼 초기화
+  useEffect(() => {
+    if (!detailQuery.data) return
+    setName(detailQuery.data.name)
+    setDescription(detailQuery.data.description)
+    setItems(
+      (detailQuery.data.productItemList ?? []).map((it) => ({
+        id: it.id,
+        name: it.name,
+        price: it.price,
+        count: it.count,
+      })),
+    )
+  }, [detailQuery.data])
+
+  const reloadAfterMutation = () => {
+    queryClient.invalidateQueries({ queryKey: ['product', productId] })
+    queryClient.invalidateQueries({ queryKey: ['seller', 'products'] })
+  }
+
+  const updateProductMutation = useMutation({
+    mutationFn: updateProduct,
+    onSuccess: () => reloadAfterMutation(),
+  })
+
+  const updateItemMutation = useMutation({
+    mutationFn: updateProductItem,
+    onSuccess: () => reloadAfterMutation(),
+  })
+
+  const addItemMutation = useMutation({
+    mutationFn: addProductItem,
+    onSuccess: () => reloadAfterMutation(),
+  })
+
+  const deleteItemMutation = useMutation({
+    mutationFn: deleteProductItem,
+    onSuccess: () => reloadAfterMutation(),
+  })
+
+  if (detailQuery.isLoading) return <p>로딩...</p>
+  if (detailQuery.isError) return <p className="err">{extractApiMessage(detailQuery.error)}</p>
+  if (!detailQuery.data) return <p>상품을 찾을 수 없습니다.</p>
+
+  const onSaveProductMeta = () => {
+    updateProductMutation.mutate({
+      productId,
+      name,
+      description,
+      updateProductItemForms: [], // 본문 메타만 수정. 옵션은 행별 PUT.
+    })
+  }
+
+  const onSaveItem = (it: ItemDraft) => {
+    if (it.id == null) {
+      addItemMutation.mutate({
+        productId,
+        name: it.name,
+        price: it.price,
+        count: it.count,
+      })
+    } else {
+      updateItemMutation.mutate({
+        id: it.id,
+        productId,
+        name: it.name,
+        price: it.price,
+        count: it.count,
+      })
+    }
+  }
+
+  const onDeleteItem = (it: ItemDraft, idx: number) => {
+    if (it.id == null) {
+      setItems((prev) => prev.filter((_, i) => i !== idx))
+      return
+    }
+    if (!confirm(`옵션 #${it.id} 삭제할까요?`)) return
+    deleteItemMutation.mutate(it.id)
+  }
+
+  const addRow = () =>
+    setItems((prev) => [...prev, { id: null, name: '', price: 0, count: 0 }])
+
+  return (
+    <section>
+      <h1>상품 수정 #{productId}</h1>
+      <div className="form" style={{ maxWidth: 640 }}>
+        <label>
+          상품명
+          <input value={name} onChange={(e) => setName(e.target.value)} />
+        </label>
+        <label>
+          설명
+          <textarea
+            rows={3}
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+          />
+        </label>
+        <button
+          type="button"
+          onClick={onSaveProductMeta}
+          disabled={updateProductMutation.isPending}
+        >
+          {updateProductMutation.isPending ? '저장 중...' : '상품 정보 저장'}
+        </button>
+        {updateProductMutation.isError && (
+          <p className="err">{extractApiMessage(updateProductMutation.error)}</p>
+        )}
+      </div>
+
+      <h2 style={{ marginTop: '2rem' }}>옵션</h2>
+      <table className="table">
+        <thead>
+          <tr>
+            <th>id</th>
+            <th>옵션명</th>
+            <th>가격</th>
+            <th>재고</th>
+            <th></th>
+          </tr>
+        </thead>
+        <tbody>
+          {items.map((it, idx) => (
+            <tr key={it.id ?? `new-${idx}`}>
+              <td>{it.id ?? <em>new</em>}</td>
+              <td>
+                <input
+                  value={it.name}
+                  onChange={(e) =>
+                    setItems((prev) =>
+                      prev.map((row, i) => (i === idx ? { ...row, name: e.target.value } : row)),
+                    )
+                  }
+                />
+              </td>
+              <td>
+                <input
+                  type="number"
+                  value={it.price}
+                  onChange={(e) =>
+                    setItems((prev) =>
+                      prev.map((row, i) =>
+                        i === idx ? { ...row, price: Number(e.target.value) } : row,
+                      ),
+                    )
+                  }
+                  style={{ width: 100 }}
+                />
+              </td>
+              <td>
+                <input
+                  type="number"
+                  value={it.count}
+                  onChange={(e) =>
+                    setItems((prev) =>
+                      prev.map((row, i) =>
+                        i === idx ? { ...row, count: Number(e.target.value) } : row,
+                      ),
+                    )
+                  }
+                  style={{ width: 80 }}
+                />
+              </td>
+              <td>
+                <button type="button" onClick={() => onSaveItem(it)}>
+                  {it.id == null ? '추가' : '저장'}
+                </button>{' '}
+                <button type="button" onClick={() => onDeleteItem(it, idx)}>
+                  삭제
+                </button>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      <p>
+        <button type="button" onClick={addRow}>
+          ＋ 옵션 행 추가
+        </button>
+      </p>
+      {(addItemMutation.isError ||
+        updateItemMutation.isError ||
+        deleteItemMutation.isError) && (
+        <p className="err">
+          {extractApiMessage(
+            addItemMutation.error ?? updateItemMutation.error ?? deleteItemMutation.error,
+          )}
+        </p>
+      )}
+
+      <p style={{ marginTop: '1rem' }}>
+        <button type="button" onClick={() => navigate('/seller/products')}>
+          ← 목록으로
+        </button>
+      </p>
+    </section>
+  )
+}

--- a/apps/web/src/routes/seller/ProductNew.tsx
+++ b/apps/web/src/routes/seller/ProductNew.tsx
@@ -1,0 +1,147 @@
+import { useFieldArray, useForm } from 'react-hook-form'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { z } from 'zod'
+import { useMutation } from '@tanstack/react-query'
+import { useNavigate } from 'react-router-dom'
+import { addProduct } from '@/shared/api/seller'
+import { extractApiMessage } from '@/shared/api/client'
+import { useAuth } from '@/shared/auth/AuthContext'
+import { rememberMyProductId } from './productStore'
+
+const itemSchema = z.object({
+  name: z.string().min(1, '옵션명을 입력하세요'),
+  // register('...', { valueAsNumber: true }) 로 string 이 number 로 변환된 후 검증.
+  price: z.number({ message: '숫자' }).int('정수').min(0, '0 이상'),
+  count: z.number({ message: '숫자' }).int('정수').min(0, '0 이상'),
+})
+
+const schema = z.object({
+  name: z.string().min(1, '상품명을 입력하세요'),
+  description: z.string().min(1, '설명을 입력하세요'),
+  addProductItemForms: z.array(itemSchema).min(1, '옵션을 1개 이상 등록하세요'),
+})
+
+type FormData = z.infer<typeof schema>
+
+export function SellerProductNew() {
+  const { user } = useAuth()
+  const navigate = useNavigate()
+
+  const {
+    register,
+    control,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<FormData>({
+    resolver: zodResolver(schema),
+    defaultValues: {
+      name: '',
+      description: '',
+      addProductItemForms: [{ name: '', price: 0, count: 0 }],
+    },
+  })
+
+  const { fields, append, remove } = useFieldArray({
+    control,
+    name: 'addProductItemForms',
+  })
+
+  const createMutation = useMutation({
+    mutationFn: addProduct,
+    onSuccess: (res) => {
+      rememberMyProductId(user?.id, res.productId)
+      navigate('/seller/products')
+    },
+  })
+
+  return (
+    <section>
+      <h1>신규 상품 등록</h1>
+      <form
+        onSubmit={handleSubmit((data) => createMutation.mutate(data))}
+        className="form"
+        style={{ maxWidth: 640 }}
+      >
+        <label>
+          상품명
+          <input {...register('name')} />
+          {errors.name && <small className="err">{errors.name.message}</small>}
+        </label>
+        <label>
+          설명
+          <textarea rows={3} {...register('description')} />
+          {errors.description && (
+            <small className="err">{errors.description.message}</small>
+          )}
+        </label>
+
+        <h2>옵션</h2>
+        {errors.addProductItemForms?.root && (
+          <p className="err">{errors.addProductItemForms.root.message}</p>
+        )}
+        <table className="table">
+          <thead>
+            <tr>
+              <th>옵션명</th>
+              <th>가격</th>
+              <th>재고</th>
+              <th></th>
+            </tr>
+          </thead>
+          <tbody>
+            {fields.map((f, idx) => (
+              <tr key={f.id}>
+                <td>
+                  <input {...register(`addProductItemForms.${idx}.name`)} />
+                  {errors.addProductItemForms?.[idx]?.name && (
+                    <small className="err">
+                      {errors.addProductItemForms[idx]?.name?.message}
+                    </small>
+                  )}
+                </td>
+                <td>
+                  <input
+                    type="number"
+                    {...register(`addProductItemForms.${idx}.price`, { valueAsNumber: true })}
+                    style={{ width: 100 }}
+                  />
+                </td>
+                <td>
+                  <input
+                    type="number"
+                    {...register(`addProductItemForms.${idx}.count`, { valueAsNumber: true })}
+                    style={{ width: 80 }}
+                  />
+                </td>
+                <td>
+                  <button
+                    type="button"
+                    onClick={() => remove(idx)}
+                    disabled={fields.length === 1}
+                  >
+                    제거
+                  </button>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+        <p>
+          <button
+            type="button"
+            onClick={() => append({ name: '', price: 0, count: 0 })}
+          >
+            ＋ 옵션 추가
+          </button>
+        </p>
+
+        <button type="submit" disabled={createMutation.isPending}>
+          {createMutation.isPending ? '등록 중...' : '상품 등록'}
+        </button>
+        {createMutation.isError && (
+          <p className="err">{extractApiMessage(createMutation.error)}</p>
+        )}
+      </form>
+    </section>
+  )
+}

--- a/apps/web/src/routes/seller/Products.tsx
+++ b/apps/web/src/routes/seller/Products.tsx
@@ -1,8 +1,90 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { Link } from 'react-router-dom'
+import { getProductListByIds } from '@/shared/api/search'
+import { deleteProduct } from '@/shared/api/seller'
+import { extractApiMessage } from '@/shared/api/client'
+import { useAuth } from '@/shared/auth/AuthContext'
+import { forgetMyProductId, getMyProductIds } from './productStore'
+
 export function SellerProducts() {
+  const { user } = useAuth()
+  const queryClient = useQueryClient()
+
+  const ids = getMyProductIds(user?.id)
+
+  const listQuery = useQuery({
+    queryKey: ['seller', 'products', user?.id, ids.join(',')],
+    queryFn: () => getProductListByIds(ids),
+    enabled: ids.length > 0,
+  })
+
+  const deleteMutation = useMutation({
+    mutationFn: (productId: number) => deleteProduct(productId),
+    onSuccess: (_msg, productId) => {
+      forgetMyProductId(user?.id, productId)
+      queryClient.invalidateQueries({ queryKey: ['seller', 'products'] })
+    },
+  })
+
+  const onDelete = (productId: number) => {
+    if (!confirm(`상품 #${productId} 을(를) 삭제할까요?`)) return
+    deleteMutation.mutate(productId)
+  }
+
   return (
     <section>
       <h1>판매자 상품 관리</h1>
-      <p>POST /api/seller/products, PUT /api/seller/products/&#123;id&#125; 연동 예정.</p>
+      <p>
+        <Link to="/seller/products/new">
+          <strong>＋ 신규 상품 등록</strong>
+        </Link>
+      </p>
+
+      {ids.length === 0 ? (
+        <p className="muted">
+          아직 등록한 상품이 없습니다. 신규 상품 등록 을 눌러 시작하세요.
+          <br />
+          <small>
+            (※ 백엔드에 SELLER 전용 상품 목록 API 가 없어, 이 화면은 이 브라우저에서 등록한
+            상품만 보여줍니다. 자세한 내용은 docs/seller-flow.md 참고.)
+          </small>
+        </p>
+      ) : listQuery.isLoading || listQuery.isFetching ? (
+        <p>불러오는 중...</p>
+      ) : listQuery.isError ? (
+        <p className="err">{extractApiMessage(listQuery.error)}</p>
+      ) : (
+        <ul className="card-list">
+          {(listQuery.data ?? []).map((p) => (
+            <li key={p.id} className="card">
+              <h3>{p.name}</h3>
+              <p className="muted">{p.description}</p>
+              <p className="muted">옵션 {p.productItemList?.length ?? 0}개</p>
+              <p>
+                <Link to={`/seller/products/${p.id}/edit`}>수정</Link>
+                {' | '}
+                <button
+                  type="button"
+                  onClick={() => onDelete(p.id)}
+                  disabled={deleteMutation.isPending}
+                  style={{
+                    border: 'none',
+                    background: 'none',
+                    color: '#c62828',
+                    cursor: 'pointer',
+                    padding: 0,
+                  }}
+                >
+                  삭제
+                </button>
+              </p>
+            </li>
+          ))}
+        </ul>
+      )}
+      {deleteMutation.isError && (
+        <p className="err">{extractApiMessage(deleteMutation.error)}</p>
+      )}
     </section>
   )
 }

--- a/apps/web/src/routes/seller/Signup.tsx
+++ b/apps/web/src/routes/seller/Signup.tsx
@@ -1,0 +1,74 @@
+import { useForm } from 'react-hook-form'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { z } from 'zod'
+import { useMutation } from '@tanstack/react-query'
+import { Link, useNavigate } from 'react-router-dom'
+import { signupSeller } from '@/shared/api/seller'
+import { extractApiMessage } from '@/shared/api/client'
+
+const schema = z.object({
+  email: z.email('올바른 이메일을 입력하세요'),
+  name: z.string().min(1, '이름을 입력하세요'),
+  password: z.string().min(8, '비밀번호는 8자 이상'),
+  birth: z.string().regex(/^\d{4}-\d{2}-\d{2}$/, 'YYYY-MM-DD 형식'),
+  phoneNum: z.string().min(1, '전화번호를 입력하세요'),
+})
+type FormData = z.infer<typeof schema>
+
+export function SellerSignup() {
+  const navigate = useNavigate()
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+    getValues,
+  } = useForm<FormData>({ resolver: zodResolver(schema) })
+
+  const signupMutation = useMutation({
+    mutationFn: signupSeller,
+    onSuccess: () => {
+      const { email } = getValues()
+      navigate(`/seller/signup/verify?email=${encodeURIComponent(email)}`)
+    },
+  })
+
+  return (
+    <section>
+      <h1>회원가입 (SELLER)</h1>
+      <form onSubmit={handleSubmit((data) => signupMutation.mutate(data))} className="form">
+        <label>
+          이메일
+          <input type="email" autoComplete="email" {...register('email')} />
+          {errors.email && <small className="err">{errors.email.message}</small>}
+        </label>
+        <label>
+          이름 / 상호
+          <input autoComplete="name" {...register('name')} />
+          {errors.name && <small className="err">{errors.name.message}</small>}
+        </label>
+        <label>
+          비밀번호 (8자 이상)
+          <input type="password" autoComplete="new-password" {...register('password')} />
+          {errors.password && <small className="err">{errors.password.message}</small>}
+        </label>
+        <label>
+          생년월일 (YYYY-MM-DD)
+          <input placeholder="1990-01-01" {...register('birth')} />
+          {errors.birth && <small className="err">{errors.birth.message}</small>}
+        </label>
+        <label>
+          전화번호
+          <input autoComplete="tel" placeholder="010-1234-5678" {...register('phoneNum')} />
+          {errors.phoneNum && <small className="err">{errors.phoneNum.message}</small>}
+        </label>
+        <button type="submit" disabled={signupMutation.isPending}>
+          {signupMutation.isPending ? '가입 중...' : '가입 신청'}
+        </button>
+        {signupMutation.isError && <p className="err">{extractApiMessage(signupMutation.error)}</p>}
+      </form>
+      <p>
+        이미 가입했나요? <Link to="/seller/login">로그인</Link>
+      </p>
+    </section>
+  )
+}

--- a/apps/web/src/routes/seller/SignupVerify.tsx
+++ b/apps/web/src/routes/seller/SignupVerify.tsx
@@ -1,0 +1,56 @@
+import { useForm } from 'react-hook-form'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { z } from 'zod'
+import { useMutation } from '@tanstack/react-query'
+import { useNavigate, useSearchParams } from 'react-router-dom'
+import { verifySellerEmail } from '@/shared/api/seller'
+import { extractApiMessage } from '@/shared/api/client'
+
+const schema = z.object({
+  email: z.email('올바른 이메일을 입력하세요'),
+  code: z.string().min(1, '인증코드를 입력하세요'),
+})
+type FormData = z.infer<typeof schema>
+
+export function SellerSignupVerify() {
+  const [params] = useSearchParams()
+  const defaultEmail = params.get('email') ?? ''
+  const navigate = useNavigate()
+
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<FormData>({
+    resolver: zodResolver(schema),
+    defaultValues: { email: defaultEmail, code: '' },
+  })
+
+  const verifyMutation = useMutation({
+    mutationFn: (data: FormData) => verifySellerEmail(data.email, data.code),
+    onSuccess: () => navigate('/seller/login'),
+  })
+
+  return (
+    <section>
+      <h1>이메일 인증 (SELLER)</h1>
+      <p>가입 시 등록한 이메일로 받은 인증코드를 입력하세요.</p>
+      <form onSubmit={handleSubmit((data) => verifyMutation.mutate(data))} className="form">
+        <label>
+          이메일
+          <input type="email" {...register('email')} />
+          {errors.email && <small className="err">{errors.email.message}</small>}
+        </label>
+        <label>
+          인증코드
+          <input {...register('code')} />
+          {errors.code && <small className="err">{errors.code.message}</small>}
+        </label>
+        <button type="submit" disabled={verifyMutation.isPending}>
+          {verifyMutation.isPending ? '인증 중...' : '인증 완료'}
+        </button>
+        {verifyMutation.isError && <p className="err">{extractApiMessage(verifyMutation.error)}</p>}
+      </form>
+    </section>
+  )
+}

--- a/apps/web/src/routes/seller/productStore.ts
+++ b/apps/web/src/routes/seller/productStore.ts
@@ -1,0 +1,39 @@
+// SELLER 가 등록한 product id 를 localStorage 에 누적.
+// 백엔드에 `GET /seller/product` 목록 API 가 없어, 검색 기반 우회용으로 두는 보조 인덱스.
+// 백엔드 API 가 추가되면 제거.
+
+const STORAGE_PREFIX = 'commerce-seller-products'
+
+function key(sellerId: number | undefined): string | null {
+  if (sellerId == null) return null
+  return `${STORAGE_PREFIX}:${sellerId}`
+}
+
+export function getMyProductIds(sellerId: number | undefined): number[] {
+  const k = key(sellerId)
+  if (!k) return []
+  try {
+    const raw = localStorage.getItem(k)
+    if (!raw) return []
+    const arr = JSON.parse(raw) as unknown
+    if (!Array.isArray(arr)) return []
+    return arr.filter((v): v is number => typeof v === 'number')
+  } catch {
+    return []
+  }
+}
+
+export function rememberMyProductId(sellerId: number | undefined, productId: number): void {
+  const k = key(sellerId)
+  if (!k) return
+  const cur = getMyProductIds(sellerId)
+  if (cur.includes(productId)) return
+  localStorage.setItem(k, JSON.stringify([...cur, productId]))
+}
+
+export function forgetMyProductId(sellerId: number | undefined, productId: number): void {
+  const k = key(sellerId)
+  if (!k) return
+  const cur = getMyProductIds(sellerId)
+  localStorage.setItem(k, JSON.stringify(cur.filter((id) => id !== productId)))
+}

--- a/apps/web/src/shared/api/client.ts
+++ b/apps/web/src/shared/api/client.ts
@@ -20,10 +20,14 @@ api.interceptors.response.use(
     if (err.response?.status === 401) {
       localStorage.removeItem(TOKEN_KEY)
       const path = window.location.pathname
-      // login/signup 화면이 아니면 로그인 페이지로
+      // login/signup 화면이 아니면 모드별 로그인 페이지로
       const isAuthPage = path.includes('/login') || path.includes('/signup')
-      if (path.startsWith('/customer') && !isAuthPage) {
-        window.location.href = '/customer/login'
+      if (!isAuthPage) {
+        if (path.startsWith('/seller')) {
+          window.location.href = '/seller/login'
+        } else if (path.startsWith('/customer')) {
+          window.location.href = '/customer/login'
+        }
       }
     }
     return Promise.reject(err)

--- a/apps/web/src/shared/api/search.ts
+++ b/apps/web/src/shared/api/search.ts
@@ -15,3 +15,12 @@ export async function getProductDetail(productId: number): Promise<ProductDto> {
   })
   return data
 }
+
+// 백엔드: GET /search/product/list?productId=1&productId=2&...
+export async function getProductListByIds(productIds: number[]): Promise<ProductDto[]> {
+  if (productIds.length === 0) return []
+  const search = new URLSearchParams()
+  productIds.forEach((id) => search.append('productId', String(id)))
+  const { data } = await api.get<ProductDto[]>(`/order/search/product/list?${search.toString()}`)
+  return data
+}

--- a/apps/web/src/shared/api/seller.ts
+++ b/apps/web/src/shared/api/seller.ts
@@ -1,0 +1,72 @@
+import { api } from './client'
+import type {
+  SignupInput,
+  SignupOutput,
+  SigninInput,
+  AddProductInput,
+  AddProductOutput,
+  AddProductItemInput,
+  UpdateProductInput,
+  UpdateProductOutput,
+  UpdateProductItemInput,
+  UpdateProductItemOutput,
+} from '@/types/dto'
+
+// nginx /api/user/seller/signup → gateway /user/seller/signup → user-api /seller/signup
+export async function signupSeller(input: SignupInput): Promise<SignupOutput> {
+  const { data } = await api.post<SignupOutput>('/user/seller/signup', input)
+  return data
+}
+
+export async function verifySellerEmail(email: string, code: string): Promise<SignupOutput> {
+  const { data } = await api.put<SignupOutput>('/user/seller/signup/verify', null, {
+    params: { email, code },
+  })
+  return data
+}
+
+// 응답 body 가 JWT 문자열 (CUSTOMER login 과 동일 패턴)
+export async function loginSeller(input: SigninInput): Promise<string> {
+  const { data } = await api.post<string>('/user/seller/login', input)
+  return data
+}
+
+// order-api /seller/product CRUD
+// gateway 가 /order/** 를 order-api 로 라우팅하므로 prefix /order 가 붙는다.
+export async function addProduct(input: AddProductInput): Promise<AddProductOutput> {
+  const { data } = await api.post<AddProductOutput>('/order/seller/product', input)
+  return data
+}
+
+export async function addProductItem(
+  input: AddProductItemInput,
+): Promise<AddProductOutput> {
+  const { data } = await api.post<AddProductOutput>('/order/seller/product/item', input)
+  return data
+}
+
+export async function updateProduct(input: UpdateProductInput): Promise<UpdateProductOutput> {
+  const { data } = await api.put<UpdateProductOutput>('/order/seller/product', input)
+  return data
+}
+
+export async function updateProductItem(
+  input: UpdateProductItemInput,
+): Promise<UpdateProductItemOutput> {
+  const { data } = await api.put<UpdateProductItemOutput>('/order/seller/product/item', input)
+  return data
+}
+
+export async function deleteProduct(id: number): Promise<string> {
+  const { data } = await api.delete<string>('/order/seller/product', {
+    params: { id },
+  })
+  return data
+}
+
+export async function deleteProductItem(id: number): Promise<string> {
+  const { data } = await api.delete<string>('/order/seller/product/item', {
+    params: { id },
+  })
+  return data
+}

--- a/apps/web/src/shared/auth/ProtectedRoute.tsx
+++ b/apps/web/src/shared/auth/ProtectedRoute.tsx
@@ -16,7 +16,8 @@ export function ProtectedRoute({ children, role, loginPath = '/customer/login' }
   }
 
   if (role && !user.roles.includes(role)) {
-    return <Navigate to="/" replace />
+    // 권한 불일치 → 모드별 로그인 화면으로 (반대 모드 토큰으로 들어왔을 때)
+    return <Navigate to={loginPath} replace />
   }
 
   return <>{children}</>

--- a/apps/web/src/types/dto.ts
+++ b/apps/web/src/types/dto.ts
@@ -90,3 +90,65 @@ export interface OrderDto {
   failureReason: string | null
   items: OrderItem[]
 }
+
+// ===== seller (order-api: /seller/product, /seller/product/item) =====
+// 백엔드 DTO 클래스명: AddProductForm / AddProductItemForm / UpdateProductForm / UpdateProductItemForm
+
+export interface AddProductItemInput {
+  productId?: number // 신규 등록 시 비움
+  name: string
+  price: number
+  count: number
+}
+
+export interface AddProductInput {
+  name: string
+  description: string
+  addProductItemForms: AddProductItemInput[]
+}
+
+export interface AddProductItemOutput {
+  id: number
+  name: string
+  price: number
+  count: number
+}
+
+export interface AddProductOutput {
+  productId: number
+  sellerId: number
+  name: string
+  description: string
+  addProductItemForms: AddProductItemOutput[]
+}
+
+export interface UpdateProductItemInput {
+  id: number
+  productId: number
+  name: string
+  price: number
+  count: number
+}
+
+export interface UpdateProductInput {
+  productId: number
+  name: string
+  description: string
+  updateProductItemForms: UpdateProductItemInput[]
+}
+
+export interface UpdateProductItemOutput {
+  id: number
+  sellerId: number
+  name: string
+  price: number
+  count: number
+}
+
+export interface UpdateProductOutput {
+  id: number
+  sellerId: number
+  name: string
+  description: string
+  updatedProductItemList: UpdateProductItemOutput[]
+}

--- a/docs/customer-flow.md
+++ b/docs/customer-flow.md
@@ -250,4 +250,4 @@ sequenceDiagram
 
 - `ProductDto` 에 `sellerId` 가 없어 `AddProductCartForm.sellerId` 를 임시로 `0` 전송 (백엔드 응답 보완 후 정정 필요).
 - 백엔드에 주문 목록 API 가 없어 `/customer/orders` 는 ID 입력 폼만 제공.
-- SELLER 화면 미구현 (별도 PR).
+- SELLER 화면은 [#50](https://github.com/jameskim9509/CommerceAPI/issues/50) 으로 분리, `docs/seller-flow.md` 참조.

--- a/docs/seller-flow.md
+++ b/docs/seller-flow.md
@@ -1,0 +1,270 @@
+# SELLER Flow
+
+`apps/web` 의 SELLER 화면과 백엔드(user-api / order-api) 사이의 전체 흐름을 swim lane 형식의 flowchart 와 시나리오별 sequence diagram 으로 정리한다. CUSTOMER 흐름과 같은 골격을 따른다 (`docs/customer-flow.md`).
+
+> 화면 구현: [#50](https://github.com/jameskim9509/CommerceAPI/issues/50)
+> 게이트웨이 라우팅: `/api/user/**` → user-api, `/api/order/**` → order-api (nginx → gateway, ADR-005 Eureka LB)
+
+---
+
+## 1. 전체 구성 (Swim Lane)
+
+```mermaid
+flowchart LR
+  subgraph User["👤 판매자 (Browser)"]
+    direction TB
+    U1[페이지 진입]
+    U2[가입/로그인 폼]
+    U3[상품 등록 / 옵션 추가]
+    U4[상품 수정 / 삭제]
+  end
+
+  subgraph SPA["⚛️ apps/web (React SPA)"]
+    direction TB
+    S1[React Router 라우팅]
+    S6[ProtectedRoute role=SELLER]
+    S2[react-hook-form + zod + useFieldArray]
+    S3[TanStack Query<br/>useQuery / useMutation]
+    S5[AuthContext<br/>localStorage 동기화]
+    S4[axios interceptor<br/>JWT 자동 주입]
+    S7[productStore<br/>내 productId 인덱스 - 임시]
+  end
+
+  subgraph Nginx["🟢 nginx (web 컨테이너)"]
+    direction TB
+    N1[SPA 정적 파일 서빙<br/>SPA fallback try_files]
+    N2["/api/* → gateway:80 프록시"]
+  end
+
+  subgraph GW["🚪 Spring Cloud Gateway"]
+    direction TB
+    G1["/user/** → lb://user-api"]
+    G2["/order/** → lb://order-api"]
+  end
+
+  subgraph UA["🧑 user-api (SellerController)"]
+    direction TB
+    UA1[POST /seller/signup<br/>이메일 코드 발송]
+    UA2[PUT /seller/signup/verify]
+    UA3[POST /seller/login<br/>JWT 발급 - ROLE_SELLER]
+  end
+
+  subgraph OA["📦 order-api"]
+    direction TB
+    OA1[POST/PUT/DELETE /seller/product<br/>SellerProductController]
+    OA2[POST/PUT/DELETE /seller/product/item]
+    OA3[GET /search/product/list?productId=...<br/>내 상품 다중 조회 - 우회]
+    OA4[GET /search/product/detail<br/>상품 + 옵션 조회]
+  end
+
+  subgraph Infra["💾 인프라"]
+    direction TB
+    I1[(MySQL: user)]
+    I2[(MySQL: order)]
+  end
+
+  U1 --> S1
+  U2 --> S2 --> S3
+  U3 --> S2
+  U4 --> S2
+  S1 --> S6
+  S3 --> S4
+  S5 -.토큰 read.-> S4
+  S7 -.id 목록.-> S3
+  S4 ==HTTP==> N2
+  N1 --> S1
+  N2 --> G1
+  N2 --> G2
+  G1 --> UA1
+  G1 --> UA2
+  G1 --> UA3
+  G2 --> OA1
+  G2 --> OA2
+  G2 --> OA3
+  G2 --> OA4
+  UA1 --> I1
+  UA2 --> I1
+  UA3 --> I1
+  OA1 --> I2
+  OA2 --> I2
+  OA3 --> I2
+  OA4 --> I2
+```
+
+**핵심 포인트**
+- 모든 외부 호출은 CUSTOMER 와 동일하게 단일 `axios` 인스턴스를 거치고, JWT 가 `Bearer` 로 자동 주입된다 (`apps/web/src/shared/api/client.ts`).
+- 401 응답 시 인터셉터가 토큰을 지우고 `/seller/*` 경로면 `/seller/login`, `/customer/*` 경로면 `/customer/login` 로 리다이렉트한다 (이번 PR 에서 모드별 분기 추가).
+- `ProtectedRoute role="SELLER" loginPath="/seller/login"` 로 가드하므로 CUSTOMER 토큰으로는 SELLER 화면에 진입할 수 없다 (반대 모드 토큰 → 같은 모드 로그인 화면으로 강제).
+- **알려진 한계 (§6 참조)**: 백엔드에 SELLER 전용 "내 상품 목록" API 가 없어, SPA 가 `productStore` (localStorage) 에 등록한 productId 를 누적하고 `GET /search/product/list?productId=...` 로 일괄 조회한다.
+
+---
+
+## 2. 시나리오별 시퀀스
+
+```mermaid
+sequenceDiagram
+  autonumber
+  actor User as 👤 Seller
+  participant SPA as ⚛️ apps/web
+  participant LS as 🗄 localStorage<br/>(JWT + productStore)
+  participant Nginx as 🟢 nginx
+  participant GW as 🚪 gateway
+  participant UA as 🧑 user-api
+  participant OA as 📦 order-api
+  participant DB as 💾 DB
+
+  rect rgb(240, 248, 255)
+    Note over User,UA: 1. 회원가입 + 이메일 인증
+    User->>SPA: 회원가입 폼 제출
+    SPA->>SPA: zod 검증 통과
+    SPA->>Nginx: POST /api/user/seller/signup
+    Nginx->>GW: POST /user/seller/signup
+    GW->>UA: POST /seller/signup
+    UA->>DB: Seller 저장 + 인증코드 발송
+    UA-->>SPA: { message }
+    SPA->>SPA: /seller/signup/verify?email= 이동
+
+    User->>SPA: 인증코드 입력 / 제출
+    SPA->>Nginx: PUT /api/user/seller/signup/verify?email=&code=
+    Nginx->>GW: 동일
+    GW->>UA: 동일
+    UA->>DB: emailVerified = true
+    UA-->>SPA: { message }
+    SPA->>SPA: /seller/login 이동
+  end
+
+  rect rgb(245, 250, 240)
+    Note over User,UA: 2. 로그인 (JWT - ROLE_SELLER)
+    User->>SPA: 이메일/비밀번호 제출
+    SPA->>Nginx: POST /api/user/seller/login
+    Nginx->>GW: 동일
+    GW->>UA: 동일
+    UA->>DB: 비밀번호 검증 + verify 여부 확인
+    UA-->>SPA: JWT 문자열 (roles=[ROLE_SELLER], id=sellerId)
+    SPA->>LS: AuthContext.login(token)<br/>commerce-token 저장
+    SPA->>SPA: 원래 가려던 경로 (location.state.from) 로 navigate
+  end
+
+  rect rgb(255, 250, 240)
+    Note over User,OA: 3. 신규 상품 등록 (Product + Items 일괄)
+    User->>SPA: 상품명/설명 + 옵션 1..n 행 입력
+    Note right of SPA: react-hook-form useFieldArray<br/>로 옵션 N행 동적 관리
+    SPA->>Nginx: POST /api/order/seller/product<br/>{ name, description, addProductItemForms[] }
+    Note right of SPA: Authorization: Bearer JWT
+    Nginx->>GW: POST /order/seller/product
+    GW->>OA: POST /seller/product (@PreAuthorize SELLER)
+    OA->>DB: Product + ProductItem cascade insert
+    OA-->>SPA: AddProductForm.Output { productId, sellerId, ... }
+    SPA->>LS: productStore.rememberMyProductId(sellerId, productId)
+    SPA->>SPA: /seller/products 이동
+  end
+
+  rect rgb(255, 245, 245)
+    Note over User,OA: 4. 내 상품 목록 (검색 기반 우회)
+    User->>SPA: /seller/products 진입
+    SPA->>LS: getMyProductIds(sellerId)
+    LS-->>SPA: [101, 102, ...]
+    SPA->>Nginx: GET /api/order/search/product/list?productId=101&productId=102
+    Nginx->>GW: 동일
+    GW->>OA: GET /search/product/list
+    OA->>DB: productRepository.findAllById(ids)
+    OA-->>SPA: ProductDto[] (옵션 포함)
+    SPA->>SPA: card-list 렌더링 + [수정/삭제] 액션
+  end
+
+  rect rgb(250, 245, 255)
+    Note over User,OA: 5. 상품 수정 (메타 + 옵션 행별)
+    User->>SPA: /seller/products/:id/edit
+    SPA->>Nginx: GET /api/order/search/product/detail?productId=:id
+    Nginx->>GW: 동일
+    GW->>OA: GET /search/product/detail
+    OA-->>SPA: ProductDto
+
+    alt 상품 정보(name/description) 저장
+      User->>SPA: [상품 정보 저장] 클릭
+      SPA->>Nginx: PUT /api/order/seller/product<br/>{ productId, name, description, updateProductItemForms:[] }
+      Nginx->>GW: 동일
+      GW->>OA: PUT /seller/product (@PreAuthorize SELLER)
+      OA->>DB: Product 메타 갱신
+      OA-->>SPA: UpdateProductForm.Output
+    end
+
+    alt 옵션 1행 신규 추가
+      User->>SPA: [추가] 클릭
+      SPA->>Nginx: POST /api/order/seller/product/item<br/>{ productId, name, price, count }
+      Nginx->>GW: 동일
+      GW->>OA: POST /seller/product/item
+      OA->>DB: ProductItem insert
+      OA-->>SPA: AddProductForm.Output
+    end
+
+    alt 옵션 1행 수정
+      User->>SPA: [저장] 클릭
+      SPA->>Nginx: PUT /api/order/seller/product/item
+      Nginx->>GW: 동일
+      GW->>OA: PUT /seller/product/item
+      OA->>DB: ProductItem update
+      OA-->>SPA: UpdateProductItemForm.Output
+    end
+
+    alt 옵션 1행 삭제
+      User->>SPA: [삭제] 클릭 → confirm
+      SPA->>Nginx: DELETE /api/order/seller/product/item?id=
+      Nginx->>GW: 동일
+      GW->>OA: DELETE /seller/product/item
+      OA->>DB: ProductItem delete
+      OA-->>SPA: "success"
+    end
+
+    SPA->>SPA: queryClient.invalidateQueries(['product', id], ['seller','products'])
+  end
+
+  rect rgb(240, 255, 240)
+    Note over User,OA: 6. 상품 삭제
+    User->>SPA: 목록에서 [삭제] 클릭 → confirm
+    SPA->>Nginx: DELETE /api/order/seller/product?id=
+    Nginx->>GW: 동일
+    GW->>OA: DELETE /seller/product
+    OA->>DB: Product + ProductItem cascade delete
+    OA-->>SPA: "success"
+    SPA->>LS: productStore.forgetMyProductId(sellerId, id)
+    SPA->>SPA: 목록 캐시 invalidate
+  end
+
+  Note over SPA: ⚠️ 토큰 만료 / 401 응답 시<br/>axios interceptor → localStorage 삭제 → /seller/login 강제 이동
+```
+
+---
+
+## 3. 화면 ↔ API 매핑
+
+| 화면 (route) | 컴포넌트 | 메서드 + 경로 | 가드 |
+|---|---|---|---|
+| `/seller/signup` | `Signup.tsx` | `POST /api/user/seller/signup` | 없음 |
+| `/seller/signup/verify` | `SignupVerify.tsx` | `PUT  /api/user/seller/signup/verify` | 없음 |
+| `/seller/login` | `Login.tsx` | `POST /api/user/seller/login` | 없음 |
+| `/seller` (index) | `Home.tsx` | 호출 없음 (인사 + 링크) | 없음 |
+| `/seller/products` | `Products.tsx` | `GET  /api/order/search/product/list?productId=...` + `DELETE /api/order/seller/product` | SELLER |
+| `/seller/products/new` | `ProductNew.tsx` | `POST /api/order/seller/product` (Product + Items 일괄) | SELLER |
+| `/seller/products/:id/edit` | `ProductEdit.tsx` | `GET /api/order/search/product/detail` + `PUT /api/order/seller/product` + `POST/PUT/DELETE /api/order/seller/product/item` | SELLER |
+| `/seller/orders` | `Orders.tsx` | (placeholder — 백엔드 미구현) | SELLER |
+
+---
+
+## 4. 관련 ADR
+
+- **ADR-005**: Eureka + gateway lb 라우팅. SPA → nginx → gateway → `lb://user-api` / `lb://order-api`. SELLER 호출도 같은 경로를 그대로 탄다.
+
+## 5. CUSTOMER 와의 모드 분리 규칙
+
+- **토큰 저장소는 공용** (`localStorage: commerce-token`) 이지만, 한 번에 하나의 모드만 사용한다 — 새로 로그인하면 이전 토큰을 덮어쓴다.
+- `AuthContext` 가 JWT payload 의 `roles` 를 보고 `Role[]` 로 변환 (`ROLE_SELLER → SELLER`), `ProtectedRoute role="SELLER"` 가드는 SELLER 가 아닌 토큰을 `/seller/login` 으로 돌려보낸다.
+- axios 401 인터셉터는 현재 URL prefix 로 모드를 판별해 각자 로그인 화면으로 보낸다.
+- CUSTOMER ↔ SELLER 헤더에 서로 모드 전환 링크를 두지만, 전환 시에는 재로그인이 필요하다.
+
+## 6. 알려진 한계
+
+- **SELLER 전용 "내 상품 목록" API 미존재**: 백엔드 `SellerProductController` 는 POST/PUT/DELETE 만 노출하고 GET 이 없다. 임시 우회로 SPA 가 `productStore` (localStorage) 에 등록한 productId 를 누적하고 `GET /search/product/list?productId=...` 로 일괄 조회한다.
+  - 결과적으로 **다른 브라우저/기기에서 로그인하면 본인이 등록한 상품이 보이지 않는다.** 백엔드에 `GET /seller/product?sellerId=` (또는 JWT 기반 자동 필터) 가 추가되면 `productStore` 를 제거해야 한다.
+- **SELLER 주문 관리 API 미존재**: 백엔드에 `GET /seller/orders` 가 없어 `/seller/orders` 는 placeholder 다. 현재 주문 상태는 CUSTOMER 모드 `/customer/orders/:id` 에서만 확인 가능.
+- `CUSTOMER` 와 마찬가지로 `ProductDto` 응답에 `sellerId` 가 포함되지 않아, CUSTOMER 가 카트에 담을 때는 임시 `sellerId=0` 을 보낸다 (`docs/customer-flow.md` §5 와 동일 한계).


### PR DESCRIPTION
## 관련 이슈

Closes #50

## 변경 유형
- [ ] 🐞 Bug fix
- [x] ✨ Feature
- [ ] 🛠 Refactor / Chore
- [ ] 🗄 DB 마이그레이션 (Flyway V_*.sql 추가)
- [x] 📝 Docs

## 요약

`apps/web` 의 SELLER 화면을 #43 (CUSTOMER) 와 동일한 구조로 채웁니다. 인증(회원가입/이메일 인증/로그인), 상품 등록/수정/삭제, 옵션 행별 CRUD 까지 백엔드 `SellerController` / `SellerProductController` 기존 API 그대로 연동했고, 흐름도와 한계를 `docs/seller-flow.md` 로 정리했습니다.

## 영향 받는 모듈
- [ ] userApi
- [ ] orderApi
- [ ] gateway
- [ ] infra (docker-compose, CI, etc.)
- [x] apps/web (frontend only)

## 동작 확인

- `pnpm --filter @commerce/web typecheck` — green
- `pnpm --filter @commerce/web build` — vite 빌드 성공 (`dist/` 산출물 생성 확인)
- `pnpm --filter @commerce/web dev` — Vite dev 서버 부팅 확인 (`http://localhost:5173`)
- 백엔드 호출 통합 검증은 `docker compose -f docker-compose.test.yml up` 환경에서 다음 시나리오로 점검 예정:
  1. `/seller/signup` → 메일 코드 발급 (Mailgun) → `/seller/signup/verify` → `/seller/login` JWT 발급
  2. `/seller/products/new` → `POST /api/order/seller/product` 로 Product + Items 일괄 등록
  3. `/seller/products` 에서 본인 등록 상품 목록 확인 (`GET /api/order/search/product/list?productId=...` 우회 — 한계 §6 참조)
  4. `/seller/products/:id/edit` 에서 메타 PUT + 옵션 POST/PUT/DELETE
  5. 목록 [삭제] → `DELETE /api/order/seller/product?id=` → `productStore` 인덱스 갱신
  6. CUSTOMER 토큰으로 `/seller/products` 접근 시 `/seller/login` 으로 강제 이동 검증

## 체크리스트
- [ ] 단위 / 통합 테스트 통과 (`./gradlew test`) — 해당 없음 (frontend only)
- [ ] DB 스키마 변경이 있다면 Flyway 마이그레이션 (`V_*.sql`) 추가 — 해당 없음
- [ ] 두 모듈에 공유되는 DTO/Authority 등 변경 시 양쪽 모두 반영 — 해당 없음 (TS 측 DTO 미러만)
- [ ] 운영 yaml(`application.yml`)에 추가된 설정이 있다면 `application-test.yml` 및 `docker-compose.test.yml`에도 반영 — 해당 없음 (yaml 변경 없음)
- [ ] 외부 API 추가/변경 시 REST Docs 컨트롤러 테스트 (`*ControllerTest`) 추가/갱신 — 해당 없음 (백엔드 변경 없음, 기존 SELLER 엔드포인트 사용)

## 알려진 한계 (docs/seller-flow.md §6)

- 백엔드에 `GET /seller/product` (내 상품 목록) 미존재 → `productStore` (localStorage) 에 본 브라우저에서 등록한 productId 누적 후 `GET /search/product/list?productId=...` 우회. 다른 브라우저/기기에서 로그인하면 본인 상품이 안 보임.
- 백엔드에 `GET /seller/orders` 미존재 → `/seller/orders` 는 placeholder + 안내.

위 두 한계는 `docs/seller-flow.md` 와 PR 본문에서 명시했고, 백엔드 API 추가 시 후속 PR 에서 `productStore` / placeholder 제거 예정.

## 스크린샷 / 로그 (선택)

라우트 추가 (`apps/web/src/router.tsx`):
- `/seller` (Home), `/seller/login`, `/seller/signup`, `/seller/signup/verify`
- `/seller/products`, `/seller/products/new`, `/seller/products/:id/edit`, `/seller/orders`