### PR TITLE
docs: HPA 전제 metrics-server 설치 절차 추가 (README·ADR-006)

### DIFF
--- a/ADR/006-kubernetes-deployment-scalability.md
+++ b/ADR/006-kubernetes-deployment-scalability.md
@@ -292,7 +292,7 @@ flowchart TB
 
 - **형상별 차이**: 앱(gateway·eureka·user-api·order-api) 행은 **prod(EKS)** 기준이며, **test(로컬)** overlay 는 replicas=1 · HPA 생략으로 패치한다. infra(mysql·redis·kafka) 행은 **test 전용 in-cluster** 값이다 (prod 는 관리형이라 이 매니페스트에 StatefulSet 자체가 없음).
 - **JVM heap**: JRE 17 컨테이너 기본 `MaxRAMPercentage` 가 25% 라 1Gi limit 에서 heap 이 ~256Mi 로 과소 할당된다. 각 앱 pod 에 `JAVA_TOOL_OPTIONS=-XX:MaxRAMPercentage=70.0` 을 주입해 limit 의 70% 를 heap 으로 쓰게 한다(Dockerfile 변경 없이 env 로).
-- **HPA**: 목표 CPU 사용률 70%(requests 기준). 예) order-api requests 500m → pod 평균 350m 초과 시 scale-out. metrics-server 필요(*남는 책임*).
+- **HPA**: 목표 CPU 사용률 70%(requests 기준). 예) order-api requests 500m → pod 평균 350m 초과 시 scale-out. metrics-server 가 전제 — 미설치 시 HPA 가 `<unknown>/70%` 로 멈춰 scale-out 불가(설치 절차는 [`k8s/README.md`](../k8s/README.md) — prod 표준 설치, test 는 kind 자체서명 우회 `--kubelet-insecure-tls`).
 - ADR-005 는 측정을 위해 **userApi 를 단일 인스턴스 고정 변수** 로 두었으나, 그것은 LB 효과 측정용 제약이었다. 운영 배포에서는 user-api 도 HA 를 위해 다중화(replicas 2 + HPA)한다.
 
 ### 헬스 체크 (probe) — Actuator 미도입 상태 기준

--- a/k8s/README.md
+++ b/k8s/README.md
@@ -48,7 +48,7 @@ kubectl kustomize k8s/overlays/prod
 외부 진입은 **nginx Ingress** 가 `/ → web` 으로만 보내고(경로 분기·rewrite 없음), web 의 nginx 가 정적 SPA 를
 서빙하면서 `/api/**` 를 내부 gateway(ClusterIP)로 프록시한다 — prod 의 ALB Ingress 형상을 로컬에서 그대로 재현한다.
 
-### 사전 1회 — Ingress 진입 준비 (클러스터 애드온, kind 기준)
+### 사전 1회 — 클러스터 애드온 (Ingress · metrics-server, kind 기준)
 
 `ingress-nginx` 컨트롤러와, kind 에서 LoadBalancer 의 EXTERNAL-IP 를 채워줄 `cloud-provider-kind` 를 설치한다.
 (다른 로컬 클러스터면 해당 LB 수단을 쓰거나, 아래 3) 의 port-forward 폴백을 사용)
@@ -65,6 +65,18 @@ kubectl -n ingress-nginx wait --for=condition=Available deploy/ingress-nginx-con
 ```bash
 docker ps --filter name=kindccm --format "{{.Names}} {{.Ports}}"
 # 예: kindccm-...  0.0.0.0:53412->80/tcp  →  브라우저 http://localhost:53412/ · API http://localhost:53412/api/user/...
+```
+
+`metrics-server` — `kubectl top`(node·pod 리소스 사용량) 확인용. test overlay 는 HPA 가 없어 **필수는
+아니지만**, kind/Docker Desktop 은 kubelet 인증서가 자체서명이라 그대로 설치하면 메트릭 수집이 실패한다 →
+`--kubelet-insecure-tls` 를 넣어 설치한다(로컬 한정 — prod 에서는 쓰지 말 것).
+
+```bash
+kubectl apply -f https://github.com/kubernetes-sigs/metrics-server/releases/latest/download/components.yaml
+# kind/Docker Desktop 자체서명 kubelet 인증서 우회 (로컬 전용)
+kubectl -n kube-system patch deploy metrics-server --type=json -p='[{"op":"add","path":"/spec/template/spec/containers/0/args/-","value":"--kubelet-insecure-tls"}]'
+kubectl -n kube-system wait --for=condition=Available deploy/metrics-server --timeout=120s
+# 확인: kubectl top nodes / kubectl -n commerce top pods
 ```
 
 ### 1) 이미지 빌드 + 로컬 클러스터에 로드
@@ -131,10 +143,20 @@ kubectl -n commerce delete pvc --all
 
 | 구성 | 용도 |
 |---|---|
-| metrics-server | HPA(CPU 메트릭) |
+| metrics-server | HPA(CPU 메트릭) — 없으면 HPA 가 `<unknown>/70%` 로 멈춰 scale-out 불가 |
 | AWS Load Balancer Controller | `ingress-alb.yaml` → ALB 프로비저닝 |
 | Cluster Autoscaler 또는 Karpenter | Node 층 자동 증감 |
 | EBS CSI Driver | (이 매니페스트는 prod 에 PVC 없음 — 관리형 DB 사용) |
+
+`metrics-server` 는 EKS 에 기본 설치되지 않으므로 HPA 적용 전에 먼저 설치한다(EKS 노드는 kubelet
+인증서가 유효해 `--kubelet-insecure-tls` 불필요 — test 의 로컬 우회와 다름). 나머지(ALB 컨트롤러·
+Autoscaler·CSI)는 클러스터 구성에 따라 별도 설치한다.
+
+```bash
+kubectl apply -f https://github.com/kubernetes-sigs/metrics-server/releases/latest/download/components.yaml
+kubectl -n kube-system wait --for=condition=Available deploy/metrics-server --timeout=120s
+kubectl top nodes   # 메트릭 수집되는지 확인
+```
 
 ### 채워야 할 placeholder (`REPLACE_WITH_*`)
 


### PR DESCRIPTION
## 관련 이슈
<!-- 후속 문서 보강 — 신규 이슈 없음. ADR-006 / #56(web 진입점) 후속 -->
Refs #54

## 변경 유형
- [ ] 🐞 Bug fix
- [ ] ✨ Feature
- [ ] 🛠 Refactor / Chore
- [ ] 🗄 DB 마이그레이션 (Flyway V_*.sql 추가)
- [x] 📝 Docs

## 요약
HPA 를 도입했으나 그 전제인 **metrics-server 설치 절차가 문서에 빠져 있어** 보강한다.
미설치 시 HPA 가 `<unknown>/70%` 로 멈춰 scale-out 이 동작하지 않는다.

## 영향 받는 모듈
- [ ] userApi
- [ ] orderApi
- [ ] gateway
- [x] infra (docker-compose, CI, etc.) — k8s README · ADR-006 (문서 한정)

## 동작 확인
- 매니페스트/코드 변경 없음 — 문서(README·ADR)만 수정
- prod: EKS 표준 설치(`components.yaml`) — kubelet 인증서 유효, 우회 불필요
- test: kind/Docker Desktop 자체서명 kubelet 우회 `--kubelet-insecure-tls` (test overlay 는 HPA 없음 → `kubectl top` 확인용)

## 체크리스트
- [x] 단위 / 통합 테스트 통과 (`./gradlew test`) — 코드 변경 없음
- [x] DB 스키마 변경이 있다면 Flyway 마이그레이션 추가 — 해당 없음
- [x] 공유 DTO/Authority 변경 시 양쪽 반영 — 해당 없음
- [x] 운영 yaml 추가 설정 반영 — 해당 없음
- [x] 외부 API 추가/변경 시 REST Docs 테스트 — 해당 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)
