### PR TITLE
chore(qa): 01-load-balancing 시나리오 독립화 — 시드 자립 + 네임스페이스 고유화

### DIFF
--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -194,7 +194,7 @@ services:
 
   # 기능/시나리오 테스트용 베이스 시드 자동 주입 (1회용).
   #   스키마는 Flyway(앱 부팅 시)가 만들므로 MySQL initdb 로는 못 넣는다 →
-  #   앱 마이그레이션으로 테이블이 생길 때까지 폴링한 뒤 functional 시드를 주입한다.
+  #   앱 마이그레이션으로 테이블이 생길 때까지 폴링한 뒤 공통 베이스 시드(루트 seed/)를 주입한다.
   #   멱등(DELETE+INSERT)이라 재기동/재실행에 안전. 영속 볼륨이 살아 있으면 데이터는 유지된다.
   db-seed:
     image: mysql:8.0
@@ -210,7 +210,7 @@ services:
       orderapi:
         condition: service_started
     volumes:
-      - ./qa/01-load-balancing/seed/functional:/seed:ro
+      - ./seed:/seed:ro
     entrypoint: ["sh", "-c"]
     command:
       - |
@@ -218,7 +218,7 @@ services:
         echo "[db-seed] waiting for Flyway-created tables ..."
         until mysql -h mysql-user  -uroot -proot user   -e 'SELECT 1 FROM customer LIMIT 1' >/dev/null 2>&1; do sleep 3; done
         until mysql -h mysql-order -uroot -proot orders -e 'SELECT 1 FROM product  LIMIT 1' >/dev/null 2>&1; do sleep 3; done
-        echo "[db-seed] seeding functional fixtures ..."
+        echo "[db-seed] seeding base fixtures ..."
         mysql -h mysql-user  -uroot -proot user   < /seed/user.sql
         mysql -h mysql-order -uroot -proot orders < /seed/order.sql
         echo "[db-seed] done."

--- a/k8s/overlays/test/infra/db-seed.yaml
+++ b/k8s/overlays/test/infra/db-seed.yaml
@@ -1,7 +1,7 @@
 # 기능/시나리오 베이스 시드 주입 Job (로컬 test 전용. prod overlay 에는 없음 — RDS).
 #  - 스키마는 user-api / order-api 의 Flyway 가 부팅 시 만든다 → MySQL 자체로는 시드 못 넣음.
-#    테이블이 생길 때까지 폴링한 뒤 functional 시드를 주입한다 (docker-compose 의 db-seed 서비스와 동형).
-#  - 시드 SQL 은 qa/01-load-balancing/seed/functional/ 을 단일 출처로 configMapGenerator(kustomization.yaml)가 ConfigMap 으로 생성.
+#    테이블이 생길 때까지 폴링한 뒤 공통 베이스 시드를 주입한다 (docker-compose 의 db-seed 서비스와 동형).
+#  - 시드 SQL 은 루트 seed/ 를 단일 출처로 configMapGenerator(kustomization.yaml)가 ConfigMap 으로 생성.
 #  - 멱등(DELETE+INSERT). 재적용 시 Job 은 spec 불변이라 `kubectl delete job db-seed -n commerce` 후 재적용.
 apiVersion: batch/v1
 kind: Job
@@ -29,7 +29,7 @@ spec:
               echo "[db-seed] waiting for Flyway-created tables ..."
               until mysql -h mysql-user  -uroot -p"$MYSQL_ROOT_PASSWORD" user   -e 'SELECT 1 FROM customer LIMIT 1' >/dev/null 2>&1; do sleep 5; done
               until mysql -h mysql-order -uroot -p"$MYSQL_ROOT_PASSWORD" orders -e 'SELECT 1 FROM product  LIMIT 1' >/dev/null 2>&1; do sleep 5; done
-              echo "[db-seed] seeding functional fixtures ..."
+              echo "[db-seed] seeding base fixtures ..."
               mysql -h mysql-user  -uroot -p"$MYSQL_ROOT_PASSWORD" user   < /seed/user.sql
               mysql -h mysql-order -uroot -p"$MYSQL_ROOT_PASSWORD" orders < /seed/order.sql
               echo "[db-seed] done."

--- a/k8s/overlays/test/kustomization.yaml
+++ b/k8s/overlays/test/kustomization.yaml
@@ -18,15 +18,15 @@ resources:
   # 외부 진입 — gateway 는 ClusterIP(base) 유지, nginx Ingress 로 노출 (prod ALB 미러)
   - ingress-nginx.yaml
 
-# db-seed Job 이 마운트할 시드 SQL. 단일 출처는 qa/01-load-balancing/seed/functional/ (compose 와 공유).
+# db-seed Job 이 마운트할 시드 SQL. 단일 출처는 루트 seed/ (compose 와 공유).
 #  - 트리 밖(../../../) 파일 참조라 standalone kustomize 는 --load-restrictor LoadRestrictionsNone 필요:
 #      kustomize build k8s/overlays/test --load-restrictor LoadRestrictionsNone | kubectl apply -f -
 #  - disableNameSuffixHash: Job 의 configMap 참조 이름(db-seed-sql)을 고정 (재적용 예측 가능).
 configMapGenerator:
   - name: db-seed-sql
     files:
-      - user.sql=../../../qa/01-load-balancing/seed/functional/user.sql
-      - order.sql=../../../qa/01-load-balancing/seed/functional/order.sql
+      - user.sql=../../../seed/user.sql
+      - order.sql=../../../seed/order.sql
     options:
       disableNameSuffixHash: true
 

--- a/qa/01-load-balancing/README.md
+++ b/qa/01-load-balancing/README.md
@@ -10,7 +10,7 @@ orderApi 인스턴스를 1 / 2 / 4 로 늘리면서 Gateway + Eureka LoadBalance
 
 ```
 qa/01-load-balancing/
-├── docker-compose.qa.yml           측정 전용 compose (작은 자원 한도 + k6 runner + db-seed). name: qa 고정
+├── docker-compose.qa.yml           측정 전용 compose (작은 자원 한도 + k6 runner + db-seed). name: qa-load-balancing 고정
 ├── run-experiments.sh              E1 / E2 / E3 자동 실행 (cart→order 워크로드)
 ├── run-experiments-order-only.sh   E1o / E2o / E3o (order-only 워크로드 — cart_add throttle 제거)
 ├── monitor-stats.sh                부하 중 docker stats + MySQL + Eureka 를 5초 간격 캡쳐
@@ -145,4 +145,4 @@ k6 워크로드는 5 % 확률로 **같은 Idempotency-Key 로 두 번 전송**.
 - Redis 카트는 k6 가 매 반복마다 동적으로 추가 (시드 SQL 범위 밖)
 - docker-compose `deploy.resources.limits` 는 Docker Desktop 에서 동작
   (Linux daemon 의 Swarm 모드와는 다르지만 단일 노드에서는 적용됨)
-- 컨테이너명은 `docker-compose.qa.yml` 의 `name: qa` 로 `qa-*` 고정 — `monitor-stats.sh` 의 `qa-mysql-order-1` 등 하드코딩이 이에 의존
+- 컨테이너명은 `docker-compose.qa.yml` 의 `name: qa-load-balancing` 으로 `qa-load-balancing-*` 고정 — `monitor-stats.sh` 의 `qa-load-balancing-mysql-order-1` 등 하드코딩이 이에 의존

--- a/qa/01-load-balancing/README.md
+++ b/qa/01-load-balancing/README.md
@@ -17,13 +17,9 @@ qa/01-load-balancing/
 ├── parse_results.py                k6 summary → 핵심 지표 표
 ├── analyze_bottleneck.py           엔드포인트별 latency 분해 (병목 식별)
 ├── analyze_monitoring.py           CPU/MySQL 모니터링 CSV → avg/p95/max
-├── seed/
-│   ├── functional/                 베이스 픽스처 (모든 환경 자동 주입 — 루트 compose·k8s 도 이 경로 참조)
-│   │   ├── user.sql                seller 1·2 + customer rich/poor/zero (id 9001+)
-│   │   └── order.sql               QA-% 상품 5 + item 8 (품절 엣지케이스 포함, id 9001+)
-│   └── load/                       k6 부하 전용 (functional 위에 추가 주입)
-│       ├── user.sql                1000 customer (customer{i}@qa.test, verify=true)
-│       └── order.sql               100 product × 5 product_item (id 1..500, 재고 1M)
+├── seed/                           이 시나리오의 자립 시드 (자기 seller + 부하 더미)
+│   ├── user.sql                    seller1(id=1) + 1000 customer (customer{i}@qa.test, verify=true)
+│   └── order.sql                   100 product × 5 product_item (id 1..500, 재고 1M, seller_id=1)
 ├── k6/
 │   ├── load-test.js                로그인→카트→주문, ramping-vus 0→200, 5 분
 │   └── load-test-order-only.js     카트 사전적재 후 order 만 (burst)
@@ -77,15 +73,11 @@ cd qa/01-load-balancing
 # 1) 스택 기동 (예: 2 인스턴스)
 docker compose -f docker-compose.qa.yml up -d --scale orderapi=2
 
-# 2) 시드 (스택 ready 후) — functional 베이스 → load 레이어 순서 (functional 이 seller 1·2 점유)
+# 2) 시드 (스택 ready 후) — user.sql(seller+customer) → order.sql(상품) 순서
 docker compose -f docker-compose.qa.yml exec -T mysql-user \
-    mysql -uroot -proot user < seed/functional/user.sql
+    mysql -uroot -proot user < seed/user.sql
 docker compose -f docker-compose.qa.yml exec -T mysql-order \
-    mysql -uroot -proot orders < seed/functional/order.sql
-docker compose -f docker-compose.qa.yml exec -T mysql-user \
-    mysql -uroot -proot user < seed/load/user.sql
-docker compose -f docker-compose.qa.yml exec -T mysql-order \
-    mysql -uroot -proot orders < seed/load/order.sql
+    mysql -uroot -proot orders < seed/order.sql
 
 # 3) k6 부하 테스트 (★ --no-deps 필수: 없으면 --scale 이 1 로 리셋됨)
 EXPERIMENT_LABEL=E2 docker compose -f docker-compose.qa.yml run --rm --no-deps k6 \
@@ -95,39 +87,38 @@ EXPERIMENT_LABEL=E2 docker compose -f docker-compose.qa.yml run --rm --no-deps k
 docker compose -f docker-compose.qa.yml down -v
 ```
 
-## 시드 구성 (functional / load)
+## 시드 구성 (자립)
 
-시드는 용도별로 두 묶음이며 **한 DB 에서 충돌 없이 공존**한다:
+이 시나리오의 `seed/` 는 **자립적**이다 — 부하 테스트에 필요한 모든 것을 스스로 만들고,
+상시환경 공통셋([루트 seed/](../../seed/))이나 다른 시나리오에 의존하지 않는다:
 
-| | `seed/functional/` | `seed/load/` |
+| | `seed/user.sql` | `seed/order.sql` |
 |---|---|---|
-| 용도 | 시나리오·수동 테스트 (품절·잔액부족 등 엣지케이스) | k6 부하 |
-| 규모 | seller 2 + customer 3, 상품 5 / item 8 | customer 1000, 상품 100 / item 500 |
-| ID 범위 | 9001+ (seller 만 1·2) | product/item 1..500 |
-| 비밀번호 | `password1!` | `password` |
-| cleanup | 자기 행만 (`customer-%`, `seller1/2`, `QA-%`) | 자기 행만 (`customer<digits>`, `QaProduct%`) |
-| 주입 | **모든 환경 자동** (db-seed) | qa 스택에서 functional 위에 추가 |
+| 내용 | seller1(id=1) + customer 1000 (`customer{i}@qa.test`) | product 100 / item 500 (id 1..500, `seller_id=1`) |
+| 규모 | 판매자 1 + 고객 1000 | 상품 100 / item 500, 재고 1M |
+| cleanup | 자기 행만 (`seller id=1`, `customer<digits>`) | 자기 행만 (`QaProduct%`) |
 
-- 공존 규칙: functional 이 **seller id 1·2 를 점유**하고, load 의 `seller_id=1` 이 이를 재사용한다 → functional 이 항상 먼저 주입돼야 한다.
-- 이메일 검증 단계 우회: SQL 로 `verify=true` 직접 INSERT
+- 주입 순서: **user.sql → order.sql** (order 의 `seller_id=1` 이 user.sql 의 seller 를 참조).
+- qa 스택은 `name: qa` 로 별도 DB 라, 자기 seller(id=1)를 만들어도 상시환경과 같은 DB 에 공존하지 않아 충돌이 없다.
+- 이메일 검증 단계 우회: SQL 로 `verify=true` 직접 INSERT.
+
+> 상시 테스트 환경(compose/k8s)의 공통 베이스 픽스처(seller 1·2, 엣지케이스 상품·고객)는
+> 이 시나리오와 분리돼 **루트 [seed/](../../seed/)** 에 있다.
 
 ## 자동 시드 (db-seed)
 
-스키마는 Flyway(앱 부팅 시 생성)라 MySQL `/docker-entrypoint-initdb.d/` 로는 못 넣는다(테이블 생성 전 실행). 그래서 **마이그레이션 후 테이블을 폴링하다 주입하는 1회용 러너**를 둔다 — functional 시드를 자동 주입:
+스키마는 Flyway(앱 부팅 시 생성)라 MySQL `/docker-entrypoint-initdb.d/` 로는 못 넣는다(테이블 생성 전 실행). 그래서 **마이그레이션 후 테이블을 폴링하다 주입하는 1회용 러너**를 둔다:
 
-- **docker compose** (`docker-compose.test.yml`, `qa/01-load-balancing/docker-compose.qa.yml`): `db-seed` 서비스. 평범한 `up` 시 자동 실행.
-  - `run-experiments*.sh` 는 `up` 의 서비스 목록에서 db-seed 를 제외하고, functional → load 를 명시적으로 주입한다.
-- **로컬 k8s** (`k8s/overlays/test`): `db-seed` Job (+ `qa/01-load-balancing/seed/functional/` 을 출처로 한 ConfigMap). 트리 밖 파일 참조라 적용 시:
+- 이 시나리오의 `docker-compose.qa.yml` `db-seed` 서비스: 평범한 `up` 시 **시나리오 자립 시드**(`./seed`)를 자동 주입.
+  - `run-experiments*.sh` 는 `up` 의 서비스 목록에서 db-seed 를 제외하고 user → order 를 명시적으로 주입한다 (중복 방지).
 
-  ```bash
-  kustomize build k8s/overlays/test --load-restrictor LoadRestrictionsNone | kubectl apply -f -
-  # 재적용 시 Job 은 불변 → kubectl delete job db-seed -n commerce 후 재적용
-  ```
-
-  → 테스트 데이터가 들어간 채로 시나리오를 바로 검증할 수 있다.
-
-> **참고**: `seed/functional/` 은 이 시나리오 폴더 안에 있지만 **프로젝트 전역 베이스 픽스처**다.
-> 루트 `docker-compose.test.yml` 과 `k8s/overlays/test` 도 이 경로를 단일 출처로 참조하므로, 수정 시 그 소비자들에도 영향을 준다.
+> 상시환경(`docker-compose.test.yml`, `k8s/overlays/test`)의 db-seed 는 이 시나리오가 아니라
+> **루트 [seed/](../../seed/)** 공통 베이스를 주입한다. k8s 는 트리 밖(`../../../seed/`) 참조라 적용 시:
+>
+> ```bash
+> kustomize build k8s/overlays/test --load-restrictor LoadRestrictionsNone | kubectl apply -f -
+> # 재적용 시 Job 은 불변 → kubectl delete job db-seed -n commerce 후 재적용
+> ```
 
 ## 멱등성 검증
 
@@ -150,7 +141,7 @@ k6 워크로드는 5 % 확률로 **같은 Idempotency-Key 로 두 번 전송**.
 
 ## 알려진 제약
 
-- 시드 SQL 의 seller_id 는 1 로 고정 (functional 이 seller1=1 점유 → load 가 재사용. functional → load 순서 보장)
+- 시드 SQL 의 seller_id 는 1 로 고정 (user.sql 이 seller1=1 생성 → order.sql 이 참조. user.sql → order.sql 순서 보장)
 - Redis 카트는 k6 가 매 반복마다 동적으로 추가 (시드 SQL 범위 밖)
 - docker-compose `deploy.resources.limits` 는 Docker Desktop 에서 동작
   (Linux daemon 의 Swarm 모드와는 다르지만 단일 노드에서는 적용됨)

--- a/qa/01-load-balancing/docker-compose.qa.yml
+++ b/qa/01-load-balancing/docker-compose.qa.yml
@@ -11,11 +11,12 @@
 #   docker compose -f qa/01-load-balancing/docker-compose.qa.yml up -d --scale orderapi=N
 #   docker compose -f qa/01-load-balancing/docker-compose.qa.yml down -v               # 정리 (볼륨 포함)
 #
-# ★ name: qa 고정 — 컨테이너명을 qa-* 로 유지해야 monitor-stats.sh 의 `qa-` 접두사/
-#   `qa-mysql-order-1` 하드코딩이 그대로 동작한다 (폴더명이 프로젝트명이 되는 기본 동작 무력화).
+# ★ name: qa-load-balancing — 시나리오별 고유 프로젝트명 (형제 시나리오 qa-consist 와 대칭).
+#   컨테이너명이 qa-load-balancing-* 로 고정돼 monitor-stats.sh 의 접두사/
+#   `qa-load-balancing-mysql-order-1` 하드코딩이 동작한다 (폴더명이 프로젝트명이 되는 기본 동작 무력화).
 # =============================================================================
 
-name: qa
+name: qa-load-balancing
 
 services:
   mysql-user:
@@ -28,13 +29,13 @@ services:
     ports:
       - "3306:3306"
     volumes:
-      - mysql-user-qa-data:/var/lib/mysql
+      - mysql-user-data:/var/lib/mysql
     healthcheck:
       test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "-pcommerce"]
       interval: 5s
       timeout: 5s
       retries: 30
-    networks: [commerce-qa]
+    networks: [commerce]
 
   mysql-order:
     image: mysql:8.0
@@ -46,13 +47,13 @@ services:
     ports:
       - "3307:3306"
     volumes:
-      - mysql-order-qa-data:/var/lib/mysql
+      - mysql-order-data:/var/lib/mysql
     healthcheck:
       test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "-pcommerce"]
       interval: 5s
       timeout: 5s
       retries: 30
-    networks: [commerce-qa]
+    networks: [commerce]
 
   redis:
     image: redis:7-alpine
@@ -63,7 +64,7 @@ services:
       interval: 5s
       timeout: 3s
       retries: 10
-    networks: [commerce-qa]
+    networks: [commerce]
 
   kafka:
     image: bitnamilegacy/kafka:3.7  # bitnami 가 namespace 를 옮겨 기존 태그는 docker.io 에서 사라짐
@@ -85,7 +86,7 @@ services:
       timeout: 5s
       retries: 20
       start_period: 30s
-    networks: [commerce-qa]
+    networks: [commerce]
 
   eureka:
     build:
@@ -104,7 +105,7 @@ services:
         limits:
           cpus: '0.5'
           memory: 512M
-    networks: [commerce-qa]
+    networks: [commerce]
 
   userapi:
     build:
@@ -132,7 +133,7 @@ services:
         limits:
           cpus: '2'
           memory: 1G
-    networks: [commerce-qa]
+    networks: [commerce]
 
   # ADR-005 측정 대상. --scale orderapi=N 으로 N 인스턴스 기동.
   orderapi:
@@ -161,7 +162,7 @@ services:
         limits:
           cpus: '2'
           memory: 1G
-    networks: [commerce-qa]
+    networks: [commerce]
 
   gateway:
     build:
@@ -181,7 +182,7 @@ services:
         limits:
           cpus: '1'
           memory: 768M
-    networks: [commerce-qa]
+    networks: [commerce]
 
   # 시나리오 자립 시드 자동 주입 (1회용). 이 시드가 자기 seller + 부하 더미를 모두 만든다.
   #   스키마는 Flyway(앱 부팅 시)가 만들므로 테이블이 생길 때까지 폴링 후 시나리오 seed 주입.
@@ -212,7 +213,7 @@ services:
         mysql -h mysql-user  -uroot -proot user   < /seed/user.sql
         mysql -h mysql-order -uroot -proot orders < /seed/order.sql
         echo "[db-seed] done."
-    networks: [commerce-qa]
+    networks: [commerce]
 
   # k6 부하 발생기. 각 실험마다 별도로 실행: docker compose run k6
   k6:
@@ -227,13 +228,13 @@ services:
       EXPERIMENT_LABEL: ${EXPERIMENT_LABEL:-unknown}
     depends_on:
       gateway: { condition: service_started }
-    networks: [commerce-qa]
+    networks: [commerce]
     # k6 run 은 run-experiments 스크립트에서 명시적으로 호출
 
 networks:
-  commerce-qa:
+  commerce:
     driver: bridge
 
 volumes:
-  mysql-user-qa-data:
-  mysql-order-qa-data:
+  mysql-user-data:
+  mysql-order-data:

--- a/qa/01-load-balancing/docker-compose.qa.yml
+++ b/qa/01-load-balancing/docker-compose.qa.yml
@@ -183,10 +183,10 @@ services:
           memory: 768M
     networks: [commerce-qa]
 
-  # 기능/시나리오 베이스 시드 자동 주입 (1회용).
-  #   스키마는 Flyway(앱 부팅 시)가 만들므로 테이블이 생길 때까지 폴링 후 functional 시드 주입.
-  #   run-experiments*.sh 는 up 의 서비스 목록에서 db-seed 를 제외하므로 부하 실험엔 영향 없고,
-  #   직접 `docker compose -f qa/01-load-balancing/docker-compose.qa.yml up -d` 하면 functional 시드가 자동 주입된다.
+  # 시나리오 자립 시드 자동 주입 (1회용). 이 시드가 자기 seller + 부하 더미를 모두 만든다.
+  #   스키마는 Flyway(앱 부팅 시)가 만들므로 테이블이 생길 때까지 폴링 후 시나리오 seed 주입.
+  #   run-experiments*.sh 는 up 의 서비스 목록에서 db-seed 를 제외하고 명시적으로 시드하므로 중복 없음.
+  #   직접 `docker compose -f qa/01-load-balancing/docker-compose.qa.yml up -d` 하면 시나리오 seed 가 자동 주입된다.
   db-seed:
     image: mysql:8.0
     restart: "no"
@@ -200,7 +200,7 @@ services:
       orderapi:
         condition: service_started
     volumes:
-      - ./seed/functional:/seed:ro
+      - ./seed:/seed:ro
     entrypoint: ["sh", "-c"]
     command:
       - |
@@ -208,7 +208,7 @@ services:
         echo "[db-seed] waiting for Flyway-created tables ..."
         until mysql -h mysql-user  -uroot -proot user   -e 'SELECT 1 FROM customer LIMIT 1' >/dev/null 2>&1; do sleep 3; done
         until mysql -h mysql-order -uroot -proot orders -e 'SELECT 1 FROM product  LIMIT 1' >/dev/null 2>&1; do sleep 3; done
-        echo "[db-seed] seeding functional fixtures ..."
+        echo "[db-seed] seeding scenario self-contained fixtures ..."
         mysql -h mysql-user  -uroot -proot user   < /seed/user.sql
         mysql -h mysql-order -uroot -proot orders < /seed/order.sql
         echo "[db-seed] done."

--- a/qa/01-load-balancing/k6/load-test.js
+++ b/qa/01-load-balancing/k6/load-test.js
@@ -47,7 +47,7 @@ const instanceIdSeen = new Trend('instance_id_seen');  // dummy: not used but ke
 function recordInstanceHit(instanceId) {
     instanceHits.add(1);
     if (!instanceId) { hitsOther.add(1); return; }
-    // 컨테이너 이름은 docker compose 가 부여 (예: qa-orderapi-1) — k6 가 받는 HOSTNAME 환경변수는 컨테이너 이름이 아니라 컨테이너 ID (12자리 hex).
+    // 컨테이너 이름은 docker compose 가 부여 (예: qa-load-balancing-orderapi-1) — k6 가 받는 HOSTNAME 환경변수는 컨테이너 이름이 아니라 컨테이너 ID (12자리 hex).
     // 여기서는 본 측정용으로 5분 동안 등장하는 unique instance id 분포 자체를 별도 객체에 누적 후 handleSummary 에서 dump.
     if (!__ENV.__INSTANCE_MAP) { /* state lives in module scope below */ }
     INSTANCE_HITS_MAP[instanceId] = (INSTANCE_HITS_MAP[instanceId] || 0) + 1;

--- a/qa/01-load-balancing/k6/load-test.js
+++ b/qa/01-load-balancing/k6/load-test.js
@@ -1,10 +1,10 @@
 // =============================================================================
 // ADR-005 시나리오 3: orderApi 다중 인스턴스 부하 분산 효과 측정
 //
-// 전제 (qa/01-load-balancing/seed/functional → load 순서로 시드 완료):
-//   - userApi DB: customer{1..1000}@qa.test, password "password", verify=true, balance=10_000_000  (load/user.sql)
-//   - orderApi DB: 100 products × 5 product_items (재고 1_000_000 각각, id 1..500)               (load/order.sql)
-//   - seller_id=1 은 functional/user.sql 이 만든 seller1 (functional 이 먼저 주입됨)
+// 전제 (qa/01-load-balancing/seed 의 user.sql → order.sql 순서로 시드 완료):
+//   - userApi DB: seller1(id=1) + customer{1..1000}@qa.test, password "password", verify=true, balance=10_000_000  (seed/user.sql)
+//   - orderApi DB: 100 products × 5 product_items (재고 1_000_000 각각, id 1..500)                                  (seed/order.sql)
+//   - seller_id=1 은 seed/user.sql 이 만든 seller1 (user.sql 이 먼저 주입됨)
 //
 // 워크로드:
 //   - ramping-vus 0 → 50 (warm-up 30s) → 200 (ramp 1m) → 200 (steady 3m) → 0 (cool-down 30s)
@@ -112,7 +112,7 @@ function login(user) {
     return token;
 }
 
-// 시드 SQL 의 product/item 이름 규칙 (qa/01-load-balancing/seed/load/order.sql 와 일치해야 refreshCart 가 메시지 추가하지 않음)
+// 시드 SQL 의 product/item 이름 규칙 (qa/01-load-balancing/seed/order.sql 와 일치해야 refreshCart 가 메시지 추가하지 않음)
 function pad3(n) { return ('000' + n).slice(-3); }
 function productName(productId) { return `QaProduct${pad3(productId)}`; }
 function productDescription(productId) { return `Product description ${productId}`; }

--- a/qa/01-load-balancing/monitor-stats.sh
+++ b/qa/01-load-balancing/monitor-stats.sh
@@ -12,7 +12,7 @@ INTERVAL=5
 
 cd "$(dirname "$0")"   # 시나리오 폴더 (qa/01-load-balancing)
 RESULTS_DIR="results"
-# 컨테이너명 qa-* 는 docker-compose.qa.yml 의 `name: qa` 로 고정됨 (아래 grep/exec 가 이에 의존).
+# 컨테이너명 qa-load-balancing-* 는 docker-compose.qa.yml 의 `name: qa-load-balancing` 으로 고정됨 (아래 grep/exec 가 이에 의존).
 
 STATS_FILE="${RESULTS_DIR}/${LABEL}-stats.csv"
 MYSQL_FILE="${RESULTS_DIR}/${LABEL}-mysql.csv"
@@ -29,17 +29,17 @@ echo "[monitor] started for $LABEL, lock=$LOCK, interval=${INTERVAL}s"
 while [ -f "$LOCK" ]; do
     TS=$(date +%H:%M:%S)
 
-    # 1) docker stats (이 스택의 qa-* 컨테이너만)
-    #    docker ps 는 프로젝트 비한정 전역 목록이라, 형제 시나리오(02-consistency, name: qa-consist)의
-    #    qa-consist-* 컨테이너가 살아 있으면 ^qa- 에 함께 걸린다 → 명시적으로 제외한다.
+    # 1) docker stats (이 스택의 qa-load-balancing-* 컨테이너만)
+    #    docker ps 는 프로젝트 비한정 전역 목록이라 프로젝트명 접두사로 이 스택만 필터한다.
+    #    (접두사가 시나리오 고유라 형제 시나리오 컨테이너와 겹치지 않는다.)
     docker stats --no-stream \
         --format '{{.Name}},{{.CPUPerc}},{{.MemUsage}},{{.MemPerc}},{{.NetIO}},{{.BlockIO}}' \
-        $(docker ps --format '{{.Names}}' | grep '^qa-' | grep -v '^qa-consist-' || true) 2>/dev/null \
+        $(docker ps --format '{{.Names}}' | grep '^qa-load-balancing-' || true) 2>/dev/null \
         | sed "s|^|${TS},|; s|/|on|g; s| GiB||g; s| MiB||g; s|%||g" \
         >> "$STATS_FILE" || true
 
     # 2) MySQL 상태 (mysql-order)
-    METRICS=$(docker exec qa-mysql-order-1 mysql -uroot -proot -BN -e "
+    METRICS=$(docker exec qa-load-balancing-mysql-order-1 mysql -uroot -proot -BN -e "
         SELECT
             (SELECT VARIABLE_VALUE FROM performance_schema.global_status WHERE VARIABLE_NAME='Threads_connected'),
             (SELECT VARIABLE_VALUE FROM performance_schema.global_status WHERE VARIABLE_NAME='Threads_running'),

--- a/qa/01-load-balancing/run-experiments-order-only.sh
+++ b/qa/01-load-balancing/run-experiments-order-only.sh
@@ -38,11 +38,9 @@ for i in "${!experiments[@]}"; do
     echo "[$LABEL] 서비스 ready 대기 ..."
     sleep 60
 
-    echo "[$LABEL] DB 시드 (functional → load) ..."
-    docker compose -f "$COMPOSE_FILE" exec -T mysql-user mysql -uroot -proot user < "$QA_DIR/seed/functional/user.sql"
-    docker compose -f "$COMPOSE_FILE" exec -T mysql-order mysql -uroot -proot orders < "$QA_DIR/seed/functional/order.sql"
-    docker compose -f "$COMPOSE_FILE" exec -T mysql-user mysql -uroot -proot user < "$QA_DIR/seed/load/user.sql"
-    docker compose -f "$COMPOSE_FILE" exec -T mysql-order mysql -uroot -proot orders < "$QA_DIR/seed/load/order.sql"
+    echo "[$LABEL] DB 시드 (user → order) ..."
+    docker compose -f "$COMPOSE_FILE" exec -T mysql-user mysql -uroot -proot user < "$QA_DIR/seed/user.sql"
+    docker compose -f "$COMPOSE_FILE" exec -T mysql-order mysql -uroot -proot orders < "$QA_DIR/seed/order.sql"
 
     echo "[$LABEL] 모니터링 시작 ..."
     bash "$QA_DIR/monitor-stats.sh" "$LABEL" &

--- a/qa/01-load-balancing/run-experiments.sh
+++ b/qa/01-load-balancing/run-experiments.sh
@@ -54,17 +54,13 @@ for i in "${!experiments[@]}"; do
     echo "[$LABEL] 서비스 ready 대기 ..."
     sleep 60   # JVM 부팅 + Eureka 등록 + Gateway registry fetch
 
-    # 4. 시드 SQL 실행 — functional 베이스(seller 1·2 점유) → load(k6) 레이어 순서.
-    #    functional 이 먼저 들어가야 load 의 seller_id=1 이 유효하다.
-    echo "[$LABEL] 시드 SQL 실행 (functional → load) ..."
+    # 4. 시드 SQL 실행 — 시나리오 자립 시드 (user.sql = seller + customer, order.sql = 상품/재고).
+    #    user.sql 이 먼저 들어가야 order.sql 의 seller_id=1 이 유효하다.
+    echo "[$LABEL] 시드 SQL 실행 (user → order) ..."
     docker compose -f "$COMPOSE_FILE" exec -T mysql-user \
-        mysql -uroot -proot user < "$QA_DIR/seed/functional/user.sql"
+        mysql -uroot -proot user < "$QA_DIR/seed/user.sql"
     docker compose -f "$COMPOSE_FILE" exec -T mysql-order \
-        mysql -uroot -proot orders < "$QA_DIR/seed/functional/order.sql"
-    docker compose -f "$COMPOSE_FILE" exec -T mysql-user \
-        mysql -uroot -proot user < "$QA_DIR/seed/load/user.sql"
-    docker compose -f "$COMPOSE_FILE" exec -T mysql-order \
-        mysql -uroot -proot orders < "$QA_DIR/seed/load/order.sql"
+        mysql -uroot -proot orders < "$QA_DIR/seed/order.sql"
 
     # 5. 모니터 백그라운드 시작 (docker stats + MySQL Threads_running 5초 간격 캡쳐)
     echo "[$LABEL] 모니터링 시작 ..."

--- a/qa/01-load-balancing/seed/order.sql
+++ b/qa/01-load-balancing/seed/order.sql
@@ -1,13 +1,13 @@
 -- =============================================================================
 -- ADR-005 시나리오 3 부하(k6) 시드 - orderApi DB (orders)
+-- 이 시나리오의 "자립 시드" (user.sql 이 만든 seller 위에 상품/재고를 얹는다).
 -- 100 개 product, 각각 ProductItem 5 개 (총 500 product_items)
 -- 재고는 1_000_000 (재고 부족이 부하 시그널을 오염시키지 않도록)
 --
 -- 가격: 1000 ~ 5000 원 (5 단계)
--- seller_id: functional/user.sql 이 만든 seller1 의 PK(=1). functional 이 먼저 주입된다.
+-- seller_id: 같은 시나리오 user.sql 이 만든 seller1 의 PK(=1). 주입 순서 user.sql → order.sql.
 -- product / product_item id = 1..100 / 1..500 강제 INSERT (load-test.js 의 산술 매핑과 일치).
---   functional/order.sql 은 9001+ 를 쓰므로 이 범위와 겹치지 않는다.
--- cleanup 은 'QaProduct%' (자기 행)만 — functional 의 'QA-%' 는 건드리지 않는다.
+-- cleanup 은 'QaProduct%' (자기 행)만 — 멱등(DELETE+INSERT) 재주입 안전.
 -- =============================================================================
 
 USE orders;
@@ -20,7 +20,7 @@ DELETE FROM product WHERE name LIKE 'QaProduct%';
 DELETE FROM outbox_events WHERE topic LIKE 'qa-%' OR created_at < NOW() - INTERVAL 30 DAY;
 DELETE FROM processed_events WHERE consumer_name LIKE 'qa-%';
 
--- seller_id 는 functional 이 만든 seller1 (id=1) 을 재사용.
+-- seller_id 는 같은 시나리오 user.sql 이 만든 seller1 (id=1).
 SET @seller_id = 1;
 
 -- 100 products. 명시적 ID 사용으로 product.id = n 보장.

--- a/qa/01-load-balancing/seed/user.sql
+++ b/qa/01-load-balancing/seed/user.sql
@@ -1,18 +1,37 @@
 -- =============================================================================
 -- ADR-005 시나리오 3 부하(k6) 시드 - userApi DB (user)
+-- 이 시나리오의 "자립 시드": 필요한 모든 데이터(seller + 대량 customer)를 스스로 만든다.
 -- 이메일 검증 (mailgun) 단계를 우회하기 위해 verify=true 로 직접 INSERT.
+--
+-- seller (id=1):
+--   order.sql 의 product.seller_id=1 및 load-test.js 카트 body(sellerId:1) 가 참조.
+--   qa 스택은 별도 DB(name: qa)라 상시환경 seller 와 공존하지 않아 PK 충돌 없음.
+--   주입 순서 user.sql → order.sql (product 가 이 seller 를 참조).
 --
 -- 1000 명의 customer:
 --   email: customer{i}@qa.test (i=1..1000)  ← load-test.js 가 이 규칙으로 로그인
 --   password: "password" (BCrypt — Spring BCryptPasswordEncoder 호환)
 --   verify: TRUE (검증 우회) / balance: 10_000_000 / role: CUSTOMER
 --
--- seller 는 만들지 않는다 — functional/user.sql 이 seller id=1·2 를 먼저 점유하고,
--- order 시드의 seller_id=1 이 그 PK 를 재사용한다 (functional → load 순서 보장).
--- cleanup 은 customer<digits>@qa.test (자기 행)만 — functional 의 customer-%@qa.test 는 보존.
+-- cleanup 은 자기 행만 (seller id=1, customer<digits>@qa.test) — 멱등 재주입 안전.
 -- =============================================================================
 
 USE `user`;
+
+-- ---------------- SELLER (id=1) — 이 시나리오가 직접 소유 ----------------
+-- product.seller_id=1 및 load-test.js 카트 body(sellerId:1) 가 참조하는 판매자.
+-- (자식 seller_roles → 부모 seller 순서로 정리)
+DELETE FROM seller_roles WHERE seller_id = 1;
+DELETE FROM seller       WHERE id = 1;
+
+INSERT INTO seller
+    (id, email, name, password, birth, phone_num, verify_expired_at, verification_code, verify, created_date, modified_date)
+VALUES
+    (1, 'seller1@qa.test', 'QA Seller 1',
+     '$2b$10$IR3iJ.0INCxQFnnjyQcKfOIiWtnArIsx2NN1J7VyV0is2BoTUly2G',
+     '1990-01-01', '010-0000-0001', NOW() + INTERVAL 1 YEAR, NULL, b'1', NOW(), NOW());
+
+INSERT INTO seller_roles (seller_id, roles) VALUES (1, 'ROLE_SELLER');
 
 -- 기존 부하 시드 정리 (FK 순서 주의, REGEXP 로 customer1..1000 만)
 DELETE FROM customer_roles           WHERE customer_id IN (SELECT id FROM (SELECT id FROM customer WHERE email REGEXP '^customer[0-9]+@qa\\.test$') AS t);
@@ -46,6 +65,8 @@ INSERT INTO customer_roles (customer_id, roles)
 SELECT id, 'ROLE_CUSTOMER' FROM customer WHERE email REGEXP '^customer[0-9]+@qa\\.test$';
 
 -- 검증
-SELECT 'customers' AS table_name, COUNT(*) AS cnt FROM customer WHERE email REGEXP '^customer[0-9]+@qa\\.test$'
+SELECT 'seller' AS table_name, COUNT(*) AS cnt FROM seller WHERE id = 1
+UNION ALL
+SELECT 'customers', COUNT(*) FROM customer WHERE email REGEXP '^customer[0-9]+@qa\\.test$'
 UNION ALL
 SELECT 'customer_roles', COUNT(*) FROM customer_roles cr JOIN customer c ON cr.customer_id = c.id WHERE c.email REGEXP '^customer[0-9]+@qa\\.test$';

--- a/qa/README.md
+++ b/qa/README.md
@@ -25,9 +25,11 @@
 
 - **인프라는 시나리오마다 자기 복제본을 가진다** — 각 폴더가 자기 `docker-compose.qa.yml` 사본을 두고,
   프로젝트명(`name:`)을 달리해 컨테이너·볼륨 네임스페이스를 분리한다 (한 번에 하나씩 8GB/8CPU 스택 기동 전제).
-- **`01-load-balancing/seed/functional/` 은 프로젝트 전역 베이스 픽스처** — 이 시나리오 폴더 안에 있지만
-  루트 [docker-compose.test.yml](../docker-compose.test.yml) 과 [k8s/overlays/test](../k8s/overlays/test) 의
-  db-seed 도 이 경로를 **단일 출처**로 참조한다. 이 파일을 수정하면 그 소비자들에도 영향을 준다.
+- **QA 시나리오는 자립 시드를 가진다** — 각 시나리오 폴더의 `seed/` 는 그 시나리오가 필요한
+  데이터(seller·부하 더미 등)를 스스로 만든다. 다른 시나리오나 상시환경에 의존하지 않는다.
+- **상시 테스트 환경의 공통 베이스는 루트 [seed/](../seed/) 에 있다** — 루트
+  [docker-compose.test.yml](../docker-compose.test.yml) 과 [k8s/overlays/test](../k8s/overlays/test) 의
+  db-seed 가 이 경로를 **단일 출처**로 참조한다. QA 시나리오와는 분리돼 있어, 서로 수정해도 영향이 없다.
 
 ## 공통 주의사항
 

--- a/seed/order.sql
+++ b/seed/order.sql
@@ -1,14 +1,15 @@
 -- =============================================================================
--- 기능/시나리오 QA seed (orderApi / orders DB) — 모든 환경에 자동 주입되는 "베이스 픽스처"
---   - 품절(재고 0)·다중 셀러 등 엣지케이스 포함 (수동/시나리오 테스트용)
+-- 상시 테스트 환경 공통 베이스 픽스처 (orderApi / orders DB)
+--   docker-compose.test.yml · k8s/overlays/test 가 이 파일을 단일 출처로 공유한다
+--   (각 환경의 db-seed 가 Flyway 테이블 생성 후 자동 주입).
+--   - 품절(재고 0)·다중 셀러 등 엣지케이스 포함 (수동/통합 테스트용)
 --   - product_item.version 은 V3 마이그레이션의 DEFAULT 0 사용
---
--- load(k6) seed 와 한 DB 에서 공존하기 위한 규칙:
---   - seller_id 1·2 는 functional/user.sql 이 만든 seller PK 와 일치.
---   - product / product_item id 는 9001+ 를 "명시적으로" 점유한다.
---     load/order.sql 이 1..100 / 1..500 을 강제 INSERT 하므로 그 범위와 절대 겹치면 안 된다.
---   - cleanup 은 'QA-%' 자기 행만 (load 의 'QaProduct%' 는 건드리지 않는다).
+--   - seller_id 1·2 는 user.sql 이 만든 seller PK 와 일치. product/item id 는 9001+ 고정.
+--   - cleanup 은 'QA-%' 자기 행만 — 멱등(DELETE+INSERT) 재주입 안전.
 --     order_items 는 product_item 에 FK 가 없으므로(스냅샷) 이름 기반 삭제로 안전.
+--
+-- 주: QA 부하 시나리오(qa/01-load-balancing)는 자기 seed 를 따로 가진 자립 구조라
+--     이 파일과 무관하다 (별도 DB). 여기서 load seed 를 참조하지 않는다.
 -- =============================================================================
 
 USE orders;

--- a/seed/user.sql
+++ b/seed/user.sql
@@ -1,14 +1,16 @@
 -- =============================================================================
--- 기능/시나리오 QA seed (userApi / user DB) — 모든 환경에 자동 주입되는 "베이스 픽스처"
+-- 상시 테스트 환경 공통 베이스 픽스처 (userApi / user DB)
+--   docker-compose.test.yml · k8s/overlays/test 가 이 파일을 단일 출처로 공유한다
+--   (각 환경의 db-seed 가 Flyway 테이블 생성 후 자동 주입). 목적: 통합테스트·수동 확인
+--   환경이 항상 "같은 세상"으로 부팅되도록 하는 표준 샘플 데이터.
 --   - 비밀번호 평문: password1!  /  BCrypt cost10 hash 아래 사용
 --   - mailgun 실패 환경이므로 verify=TRUE / verification_code=NULL 로 검증 완료 상태
 --   - roles 컬럼 값은 Authority enum 의 getRole() == "ROLE_CUSTOMER" / "ROLE_SELLER"
+--   - seller id 1·2 / customer id 9001+ 를 명시적 고정 PK 로 점유 (안정적 참조용).
+--   - cleanup 은 자기 행만 (customer-%, seller1/2) — 멱등(DELETE+INSERT) 재주입 안전.
 --
--- load(k6) seed 와 한 DB 에서 공존하기 위한 규칙:
---   - seller 는 id 1·2 를 "명시적으로" 점유한다. orderApi product.seller_id=1/2 및
---     load/order.sql 의 seller_id=1 이 이 PK 를 그대로 참조한다 (functional 이 항상 먼저 주입됨).
---   - customer 는 9001+ 고 ID 를 쓴다. load/user.sql 의 customer1..1000 과 절대 겹치지 않게.
---   - cleanup 은 "자기 행"만 (customer-%, seller1/2) — load seed 의 customer<digits> 는 건드리지 않는다.
+-- 주: QA 부하 시나리오(qa/01-load-balancing)는 자기 seed 를 따로 가진 자립 구조라
+--     이 파일과 무관하다 (별도 DB · 별도 seller). 여기서 load seed 를 참조하지 않는다.
 -- =============================================================================
 
 USE `user`;


### PR DESCRIPTION
## 관련 이슈
Closes #68

## 변경 유형
- [x] 🛠 Refactor / Chore
- [x] 📝 Docs

## 요약
01-load-balancing QA 시나리오를 **독립적**으로 만든다. 두 축:

1. **시드 자립** — 상시환경 공통 베이스는 루트 `seed/` 로 분리(단일 출처 유지), QA 시나리오는 자기 seller 를 직접 만드는 자립 시드로 전환해 functional 의존 제거.
2. **네임스페이스 고유화** — 프로젝트명 `qa` → `qa-load-balancing` (형제 `qa-consist` 와 대칭), 볼륨·네트워크 이름의 중복 `qa` 제거. `monitor-stats.sh` 의 `qa-consist` 예외 grep 도 제거.

외부 동작(환경 부팅 데이터 · k6 부하)은 동일하다.

- `chore`: functional → 루트 `seed/`, compose.test · k8s 참조 갱신
- `refactor`: load 시드 seller 추가 · 평탄화 · 자립화 / 프로젝트명 · 볼륨 · 네트워크 고유화
- `docs`: qa/README · 01-load-balancing/README 재작성

## 영향 받는 모듈
- [x] infra (docker-compose, k8s, qa 하네스)

## 동작 확인
정적 검증 (경로 해석 · 네임스페이스):
- `docker compose -f docker-compose.test.yml config` → db-seed 볼륨 = `…/seed` (루트) ✓
- `docker compose -f qa/01-load-balancing/docker-compose.qa.yml config` → 볼륨 = `…/qa/01-load-balancing/seed`, 프로젝트명 `qa-load-balancing`, 리소스 `qa-load-balancing_{commerce, mysql-user-data, mysql-order-data}` ✓
- `kubectl kustomize k8s/overlays/test --load-restrictor=LoadRestrictionsNone` → `db-seed-sql` ConfigMap 이 루트 `seed/*.sql` 로 정상 생성 ✓
- `bash -n` run · monitor 스크립트 문법 OK ✓
- 잔존 `seed/functional` · `seed/load` · `commerce-qa` · `*-qa-data` · `name: qa` 참조 = 0 ✓

> 실제 데이터 주입 · 부하까지의 end-to-end 는 8GB/8CPU 스택 `up` 이 필요해 이번엔 **정적 검증까지만** 수행했다.

## 체크리스트
- [ ] 단위 / 통합 테스트 통과 (`./gradlew test`) — 해당 없음 (시드/인프라 재배치, 앱 코드 무변경)
- [ ] DB 스키마 변경 시 Flyway 마이그레이션 — 해당 없음 (스키마 무변경)
- [ ] 공유 DTO/Authority 변경 시 양쪽 반영 — 해당 없음
- [x] 운영 yaml 설정 동기화 — 시드 경로 변경을 compose.test / qa compose / k8s 모두 반영
- [ ] 외부 API 추가/변경 시 REST Docs — 해당 없음